### PR TITLE
chore: package.jsonなどをcodeowner除外とする

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
 * @book000
+package.json
+pnpm-lock.yaml


### PR DESCRIPTION
ちょっと負担がデカいので…

- renovate-approve を入れて、自動でApproveされるように
- package.json と pnpm-lock.yaml のみ除外
- Approve 必須数は 1 としている