### PR TITLE
fix: TypeScript v6 の非推奨設定を修正する

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,8 @@
 {
   "compilerOptions": {
-    "ignoreDeprecations": "6.0",
     "target": "es2020",
     "module": "commonjs",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "lib": ["ESNext", "esnext.AsyncIterable"],
     "rootDir": "./src",
     "outDir": "./dist",
@@ -23,12 +22,11 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "experimentalDecorators": true,
-    "baseUrl": ".",
     "newLine": "LF",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     },
-    "types": ["jest"]
+    "types": ["jest", "node"]
   },
   "include": ["src/**/*", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
## 概要

TypeScript v6.0 の破壊的変更に対応するため、`tsconfig.json` の非推奨設定を修正します。

## 変更内容

- `"ignoreDeprecations": "6.0"` を削除（根本的な修正により不要）
- `"moduleResolution": "Node"` → `"moduleResolution": "bundler"` に変更（TS5107 エラー対応）
- `"baseUrl": "."` を削除（TS5101 エラー対応）
- `paths` のエイリアスを `"@/*": ["src/*"]` → `"@/*": ["./src/*"]` に更新（`baseUrl` 削除に伴う相対パス化）
- `"types"` に `"node"` を追加（Node.js の型定義を明示的に指定）

## 動作確認

- `pnpm run lint:tsc` （tsc によるタイプチェック）が正常に通ることを確認

Fixes #2042