### PR TITLE
fix: resolve eslint-plugin-unicorn violations ahead of @book000/eslint-config 1.15.44

### DIFF
--- a/src/commands/akakese.ts
+++ b/src/commands/akakese.ts
@@ -10,13 +10,13 @@ export class AkakeseCommand implements BaseCommand {
   async execute(
     _discord: Discord,
     message: Message<true>,
-    args: string[]
+    arguments_: string[]
   ): Promise<void> {
     // GIFファイルのパス
     const assetDirectory = process.env.ASSETS_DIR ?? 'assets'
     const gifPath = `${assetDirectory}/akakese.gif`
 
-    const mentionTo = this.getMentionTo(message.author, args)
+    const mentionTo = this.getMentionTo(message.author, arguments_)
 
     const buffer = fs.readFileSync(gifPath)
     await message.channel.send({
@@ -32,18 +32,18 @@ export class AkakeseCommand implements BaseCommand {
     })
   }
 
-  private getMentionTo(author: User, args: string[]): string {
-    if (args.length === 0) {
+  private getMentionTo(author: User, arguments_: string[]): string {
+    if (arguments_.length === 0) {
       return `<@${author.id}>`
     }
 
     // 数値なら、IDとみなす
-    if (/^\d+$/.test(args[0])) {
-      return `<@${args[0]}>`
+    if (/^\d+$/.test(arguments_[0])) {
+      return `<@${arguments_[0]}>`
     }
 
     // メンションを解釈する
-    const mentionTo = args[0]
+    const mentionTo = arguments_[0]
       .replace(/<@!?(\d+)>/, (_, id) => `<@${id}>`)
       .replace(/<@&(\d+)>/, (_, id) => `<@&${id}>`)
       .replace(/<@#(\d+)>/, (_, id) => `<@#${id}>`)

--- a/src/commands/birthday.ts
+++ b/src/commands/birthday.ts
@@ -11,7 +11,7 @@ export class BirthdayCommand implements BaseCommand {
   async execute(
     discord: Discord,
     message: Message<true>,
-    args: string[]
+    arguments_: string[]
   ): Promise<void> {
     // birthday: 設定されている誕生日を表示
     // birthday set 2000-01-01: 誕生日を設定
@@ -19,19 +19,19 @@ export class BirthdayCommand implements BaseCommand {
     // birthday delete: 誕生日を削除
     // それ以外: ヘルプを表示
 
-    if (args.length === 0) {
+    if (arguments_.length === 0) {
       await this.executeGet(discord, message)
       return
     }
 
-    const subCommand = args[0]
+    const subCommand = arguments_[0]
     switch (subCommand) {
       case 'set': {
-        await this.executeSet(discord, message, args.slice(1))
+        await this.executeSet(discord, message, arguments_.slice(1))
         break
       }
       case 'force': {
-        await this.executeForce(discord, message, args.slice(1))
+        await this.executeForce(discord, message, arguments_.slice(1))
         break
       }
       case 'delete': {
@@ -87,10 +87,10 @@ export class BirthdayCommand implements BaseCommand {
   async executeSet(
     _discord: Discord,
     message: Message<true>,
-    args: string[]
+    arguments_: string[]
   ): Promise<void> {
     // birthday set 2000-01-01
-    const inputDate = Birthday.parseInputDate(args.join(' '))
+    const inputDate = Birthday.parseInputDate(arguments_.join(' '))
 
     if (!inputDate) {
       const embed = this.createEmbed(
@@ -142,11 +142,11 @@ export class BirthdayCommand implements BaseCommand {
   async executeForce(
     _discord: Discord,
     message: Message<true>,
-    args: string[]
+    arguments_: string[]
   ): Promise<void> {
     // birthday force 20
 
-    const age = Number.parseInt(args[0])
+    const age = Number.parseInt(arguments_[0])
     if (!age) {
       const embed = this.createEmbed(
         'error',

--- a/src/commands/controrandja.ts
+++ b/src/commands/controrandja.ts
@@ -10,8 +10,8 @@ export class ContorandjaCommand implements BaseCommand {
   async execute(
     discord: Discord,
     message: Message<true>,
-    args: string[]
+    arguments_: string[]
   ): Promise<void> {
-    await new TochaosCommand().execute(discord, message, args)
+    await new TochaosCommand().execute(discord, message, arguments_)
   }
 }

--- a/src/commands/getatama.ts
+++ b/src/commands/getatama.ts
@@ -15,7 +15,7 @@ export class GetAtamaCommand implements BaseCommand {
   async execute(
     discord: Discord,
     message: Message<true>,
-    args: string[]
+    arguments_: string[]
   ): Promise<void> {
     const config = discord.getConfig()
     const apiUrl = config.get('phrasePlusApiUrl')
@@ -35,7 +35,7 @@ export class GetAtamaCommand implements BaseCommand {
     // 引数が指定されている場合、それをcountとして使う
     // そうでない場合、countは1
     // 引数が数値でない場合、エラー
-    const count = args[0] ? Number.parseInt(args[0]) : 1
+    const count = arguments_[0] ? Number.parseInt(arguments_[0]) : 1
     if (Number.isNaN(count) || count < 1 || count > 100) {
       await message.reply(
         ':x: 引数が間違っています。`/getatama <取得する数>` の形式で入力してください。取得する数は半角数字で1以上100未満です。'
@@ -45,13 +45,13 @@ export class GetAtamaCommand implements BaseCommand {
 
     const url = new URL(apiUrl)
     url.searchParams.set('count', count.toString())
-    const res = await fetch(url.toString())
-    if (!res.ok) {
+    const response = await fetch(url.href)
+    if (!response.ok) {
       await message.reply({
         embeds: [
           {
             title: 'エラー',
-            description: `APIリクエストに失敗しました: ${res.status} ${res.statusText}`,
+            description: `APIリクエストに失敗しました: ${response.status} ${response.statusText}`,
             color: 0xff_00_00,
           },
         ],
@@ -59,7 +59,7 @@ export class GetAtamaCommand implements BaseCommand {
       return
     }
 
-    const data = (await res.json()) as PhrasePlusResponse
+    const data = (await response.json()) as PhrasePlusResponse
     if (!('results' in data)) {
       await message.reply({
         embeds: [

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -38,11 +38,11 @@ export abstract class BaseCommand {
    *
    * @param {Discord} discord Discordインスタンス
    * @param {Message} message Discordメッセージ
-   * @param {string[]} args コマンド引数
+   * @param {string[]} arguments_ コマンド引数
    */
   abstract execute(
     discord: Discord,
     message: Message<true>,
-    args: string[]
+    arguments_: string[]
   ): Promise<void>
 }

--- a/src/commands/origin.ts
+++ b/src/commands/origin.ts
@@ -10,16 +10,16 @@ export class OriginCommand implements BaseCommand {
   async execute(
     _discord: Discord,
     message: Message<true>,
-    args: string[]
+    arguments_: string[]
   ): Promise<void> {
-    if (args.length === 0) {
+    if (arguments_.length === 0) {
       await message.reply(
         ':x: 引数が足りません。`/origin <記念日ナンバー>` の形式で入力してください。'
       )
       return
     }
 
-    const index = Number.parseInt(args[0])
+    const index = Number.parseInt(arguments_[0])
     if (Number.isNaN(index)) {
       await message.reply(
         ':x: 引数が間違っています。`/origin <記念日ナンバー>` の形式で入力してください。記念日ナンバーは半角数字です。'

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -10,10 +10,10 @@ export class SearchCommand implements BaseCommand {
   async execute(
     discord: Discord,
     message: Message<true>,
-    args: string[]
+    arguments_: string[]
   ): Promise<void> {
     // 引数がない場合はエラーを返す
-    if (args.length === 0) {
+    if (arguments_.length === 0) {
       await message.reply({
         embeds: [
           new EmbedBuilder()
@@ -25,7 +25,7 @@ export class SearchCommand implements BaseCommand {
       })
       return
     }
-    const text = args.join(' ')
+    const text = arguments_.join(' ')
 
     // APIキーの取得
     const googleSearchConfig = discord.getConfig().get('googleSearch')

--- a/src/commands/searchimg.ts
+++ b/src/commands/searchimg.ts
@@ -10,10 +10,10 @@ export class SearchImageCommand implements BaseCommand {
   async execute(
     discord: Discord,
     message: Message<true>,
-    args: string[]
+    arguments_: string[]
   ): Promise<void> {
     // 引数がない場合はエラーを返す
-    if (args.length === 0) {
+    if (arguments_.length === 0) {
       await message.reply({
         embeds: [
           new EmbedBuilder()
@@ -25,7 +25,7 @@ export class SearchImageCommand implements BaseCommand {
       })
       return
     }
-    const text = args.join(' ')
+    const text = arguments_.join(' ')
 
     // APIキーの取得
     const googleSearchConfig = discord.getConfig().get('googleSearch')

--- a/src/commands/setbanner.ts
+++ b/src/commands/setbanner.ts
@@ -10,7 +10,7 @@ export class SetbannerCommand implements BaseCommand {
   async execute(
     _discord: Discord,
     message: Message<true>,
-    args: string[]
+    arguments_: string[]
   ): Promise<void> {
     const { author } = message
 
@@ -41,29 +41,29 @@ export class SetbannerCommand implements BaseCommand {
     }
 
     const canvas = createCanvas(960, 540)
-    const ctx = canvas.getContext('2d')
+    const context = canvas.getContext('2d')
     const templateImage = await loadImage(templateImagePath)
-    ctx.drawImage(templateImage, 0, 0, 960, 540)
+    context.drawImage(templateImage, 0, 0, 960, 540)
 
     // テキストを描画
-    const text = args.join(' ').replaceAll('ー', '┃')
+    const text = arguments_.join(' ').replaceAll('ー', '┃')
 
     // 自動でフォントサイズを調整。フォントサイズ144pxを最大として、縦幅500pxに収まるようにする
     const textLength = text.length
     const fontSize = Math.min(144, 500 / (textLength * 1.3))
     const fontNames = fonts.map((font) => `'${font.name}'`).join(', ')
-    ctx.font = `${fontSize * 1.4}px ${fontNames}`
-    ctx.fillStyle = 'black'
-    ctx.textAlign = 'center'
-    ctx.textBaseline = 'middle'
+    context.font = `${fontSize * 1.4}px ${fontNames}`
+    context.fillStyle = 'black'
+    context.textAlign = 'center'
+    context.textBaseline = 'middle'
 
     // eslint-disable-next-line @typescript-eslint/no-misused-spread -- unicorn/prefer-spread と競合
     const characters = [...text]
     const lineHeight = fontSize * 1.4
-    for (let i = 0; i < characters.length; i++) {
-      const char = characters[i]
-      const yOffset = (i - (characters.length - 1) / 2) * lineHeight
-      ctx.fillText(char, x, y + yOffset)
+    for (let index = 0; index < characters.length; index++) {
+      const char = characters[index]
+      const yOffset = (index - (characters.length - 1) / 2) * lineHeight
+      context.fillText(char, x, y + yOffset)
     }
 
     // 画像をバナー画像として設定

--- a/src/commands/setbannerextra.ts
+++ b/src/commands/setbannerextra.ts
@@ -23,7 +23,7 @@ export class SetbannerExtraCommand implements BaseCommand {
   async execute(
     _discord: Discord,
     message: Message<true>,
-    args: string[]
+    arguments_: string[]
   ): Promise<void> {
     const { author } = message
 
@@ -31,22 +31,6 @@ export class SetbannerExtraCommand implements BaseCommand {
     const assetDirectory = process.env.ASSETS_DIR ?? 'assets'
     const templateBaseImagePath = `${assetDirectory}/setbanner-template-base.png`
     const templateOverlayImagePath = `${assetDirectory}/setbanner-template-overlay.png`
-
-    // 左側テキストの描画位置
-    const leftX = 100
-    const leftY = 265
-
-    // 左側絵文字の描画位置
-    const leftEmojiX = 300
-    const leftEmojiY = 280
-
-    // 右側絵文字の描画位置
-    const rightEmojiX = 600
-    const rightEmojiY = 280
-
-    // 右側テキストの描画位置
-    const rightX = 845
-    const rightY = 265
 
     // 画像を生成
     const fonts = [
@@ -67,17 +51,17 @@ export class SetbannerExtraCommand implements BaseCommand {
     }
 
     const canvas = createCanvas(960, 540)
-    const ctx = canvas.getContext('2d')
+    const context = canvas.getContext('2d')
     const templateImage = await loadImage(templateBaseImagePath)
-    ctx.drawImage(templateImage, 0, 0, 960, 540)
+    context.drawImage(templateImage, 0, 0, 960, 540)
 
     // 引数を処理
     // 1: 左側テキスト
     // 2: 左側絵文字
     // 3: 右側絵文字
     // 4: 右側テキスト
-    args = args.map((arg) => arg.trim())
-    if (args.length < 4) {
+    arguments_ = arguments_.map((argument) => argument.trim())
+    if (arguments_.length < 4) {
       await message.channel.send({
         embeds: [
           new EmbedBuilder()
@@ -91,12 +75,28 @@ export class SetbannerExtraCommand implements BaseCommand {
       return
     }
 
+    // 左側テキストの描画位置
+    const leftX = 100
+    const leftY = 265
+
+    // 左側絵文字の描画位置
+    const leftEmojiX = 300
+    const leftEmojiY = 280
+
+    // 右側絵文字の描画位置
+    const rightEmojiX = 600
+    const rightEmojiY = 280
+
+    // 右側テキストの描画位置
+    const rightX = 845
+    const rightY = 265
+
     // 左側テキストと絵文字
-    const leftText = args[0].replaceAll('ー', '┃')
-    const leftEmoji = args[1]
+    const leftText = arguments_[0].replaceAll('ー', '┃')
+    const leftEmoji = arguments_[1]
     // 右側絵文字とテキスト
-    const rightEmoji = args[2]
-    const rightText = args[3].replaceAll('ー', '┃')
+    const rightEmoji = arguments_[2]
+    const rightText = arguments_[3].replaceAll('ー', '┃')
 
     // 絵文字文字列をパース
     const leftEmojiParsed = await this.parseEmojiText(leftEmoji)
@@ -104,7 +104,7 @@ export class SetbannerExtraCommand implements BaseCommand {
 
     // 絵文字を描画
     if (leftEmojiParsed.image) {
-      ctx.drawImage(
+      context.drawImage(
         leftEmojiParsed.image,
         leftEmojiX - 70,
         leftEmojiY - 70,
@@ -113,7 +113,7 @@ export class SetbannerExtraCommand implements BaseCommand {
       )
     } else {
       this.drawText(
-        ctx,
+        context,
         leftEmojiParsed.text ?? leftEmoji,
         leftEmojiX + 32,
         leftEmojiY + 32,
@@ -121,7 +121,7 @@ export class SetbannerExtraCommand implements BaseCommand {
       )
     }
     if (rightEmojiParsed.image) {
-      ctx.drawImage(
+      context.drawImage(
         rightEmojiParsed.image,
         rightEmojiX - 70,
         rightEmojiY - 70,
@@ -130,7 +130,7 @@ export class SetbannerExtraCommand implements BaseCommand {
       )
     } else {
       this.drawText(
-        ctx,
+        context,
         rightEmojiParsed.text ?? rightEmoji,
         rightEmojiX + 32,
         rightEmojiY + 32,
@@ -139,12 +139,12 @@ export class SetbannerExtraCommand implements BaseCommand {
     }
 
     // テキストを描画
-    this.drawText(ctx, leftText, leftX, leftY, fonts)
-    this.drawText(ctx, rightText, rightX, rightY, fonts)
+    this.drawText(context, leftText, leftX, leftY, fonts)
+    this.drawText(context, rightText, rightX, rightY, fonts)
 
     // オーバーレイ画像を描画
     const overlayImage = await loadImage(templateOverlayImagePath)
-    ctx.drawImage(overlayImage, 0, 0, 960, 540)
+    context.drawImage(overlayImage, 0, 0, 960, 540)
 
     // 画像をバナー画像として設定
     const buffer = canvas.toBuffer('image/png')
@@ -206,7 +206,7 @@ export class SetbannerExtraCommand implements BaseCommand {
   }
 
   drawText(
-    ctx: CanvasRenderingContext2D,
+    context: CanvasRenderingContext2D,
     text: string,
     x: number,
     y: number,
@@ -216,18 +216,18 @@ export class SetbannerExtraCommand implements BaseCommand {
     const textLength = text.length
     const fontSize = Math.min(144, 500 / (textLength * 1.3))
     const fontNames = fonts.map((font) => `'${font.name}'`).join(', ')
-    ctx.font = `${fontSize * 1.4}px ${fontNames}`
-    ctx.fillStyle = 'black'
-    ctx.textAlign = 'center'
-    ctx.textBaseline = 'middle'
+    context.font = `${fontSize * 1.4}px ${fontNames}`
+    context.fillStyle = 'black'
+    context.textAlign = 'center'
+    context.textBaseline = 'middle'
 
     // eslint-disable-next-line @typescript-eslint/no-misused-spread -- unicorn/prefer-spread と競合
     const characters = [...text]
     const lineHeight = fontSize * 1.4
-    for (let i = 0; i < characters.length; i++) {
-      const char = characters[i]
-      const yOffset = (i - (characters.length - 1) / 2) * lineHeight
-      ctx.fillText(char, x, y + yOffset)
+    for (let index = 0; index < characters.length; index++) {
+      const char = characters[index]
+      const yOffset = (index - (characters.length - 1) / 2) * lineHeight
+      context.fillText(char, x, y + yOffset)
     }
   }
 }

--- a/src/commands/toar.ts
+++ b/src/commands/toar.ts
@@ -10,9 +10,9 @@ export class ToarCommand implements BaseCommand {
   async execute(
     discord: Discord,
     message: Message<true>,
-    args: string[]
+    arguments_: string[]
   ): Promise<void> {
-    const text = args.join(' ')
+    const text = arguments_.join(' ')
 
     const config = discord.getConfig()
     const translate = new Translate(config)

--- a/src/commands/toarja.ts
+++ b/src/commands/toarja.ts
@@ -10,9 +10,9 @@ export class ToarjaCommand implements BaseCommand {
   async execute(
     discord: Discord,
     message: Message<true>,
-    args: string[]
+    arguments_: string[]
   ): Promise<void> {
-    const text = args.join(' ')
+    const text = arguments_.join(' ')
 
     const config = discord.getConfig()
     const translate = new Translate(config)

--- a/src/commands/tochaos.ts
+++ b/src/commands/tochaos.ts
@@ -10,9 +10,9 @@ export class TochaosCommand implements BaseCommand {
   async execute(
     discord: Discord,
     message: Message<true>,
-    args: string[]
+    arguments_: string[]
   ): Promise<void> {
-    const text = args.join(' ')
+    const text = arguments_.join(' ')
 
     const config = discord.getConfig()
     const translate = new Translate(config)
@@ -22,7 +22,7 @@ export class TochaosCommand implements BaseCommand {
     const afterLanguages: string[] = []
     // 3 から 5 の間のランダムな数値を生成
     const translateCount = Math.floor(Math.random() * 3) + 3
-    for (let i = 0; i < translateCount; i++) {
+    for (let index = 0; index < translateCount; index++) {
       const excludes = [beforeLanguage, ...afterLanguages, 'ja']
       afterLanguages.push(translate.randomLanguage(excludes))
     }

--- a/src/commands/toen.ts
+++ b/src/commands/toen.ts
@@ -10,9 +10,9 @@ export class ToenCommand implements BaseCommand {
   async execute(
     discord: Discord,
     message: Message<true>,
-    args: string[]
+    arguments_: string[]
   ): Promise<void> {
-    const text = args.join(' ')
+    const text = arguments_.join(' ')
 
     const config = discord.getConfig()
     const translate = new Translate(config)

--- a/src/commands/tohe.ts
+++ b/src/commands/tohe.ts
@@ -10,9 +10,9 @@ export class ToheCommand implements BaseCommand {
   async execute(
     discord: Discord,
     message: Message<true>,
-    args: string[]
+    arguments_: string[]
   ): Promise<void> {
-    const text = args.join(' ')
+    const text = arguments_.join(' ')
 
     const config = discord.getConfig()
     const translate = new Translate(config)

--- a/src/commands/toheja.ts
+++ b/src/commands/toheja.ts
@@ -10,9 +10,9 @@ export class TohejaCommand implements BaseCommand {
   async execute(
     discord: Discord,
     message: Message<true>,
-    args: string[]
+    arguments_: string[]
   ): Promise<void> {
-    const text = args.join(' ')
+    const text = arguments_.join(' ')
 
     const config = discord.getConfig()
     const translate = new Translate(config)

--- a/src/commands/toja.ts
+++ b/src/commands/toja.ts
@@ -10,9 +10,9 @@ export class TojaCommand implements BaseCommand {
   async execute(
     discord: Discord,
     message: Message<true>,
-    args: string[]
+    arguments_: string[]
   ): Promise<void> {
-    const text = args.join(' ')
+    const text = arguments_.join(' ')
 
     const config = discord.getConfig()
     const translate = new Translate(config)

--- a/src/commands/tojaen.ts
+++ b/src/commands/tojaen.ts
@@ -10,9 +10,9 @@ export class TojaenCommand implements BaseCommand {
   async execute(
     discord: Discord,
     message: Message<true>,
-    args: string[]
+    arguments_: string[]
   ): Promise<void> {
-    const text = args.join(' ')
+    const text = arguments_.join(' ')
 
     const config = discord.getConfig()
     const translate = new Translate(config)

--- a/src/commands/tokoja.ts
+++ b/src/commands/tokoja.ts
@@ -10,9 +10,9 @@ export class TokojaCommand implements BaseCommand {
   async execute(
     discord: Discord,
     message: Message<true>,
-    args: string[]
+    arguments_: string[]
   ): Promise<void> {
-    const text = args.join(' ')
+    const text = arguments_.join(' ')
 
     const config = discord.getConfig()
     const translate = new Translate(config)

--- a/src/commands/torandja.ts
+++ b/src/commands/torandja.ts
@@ -10,9 +10,9 @@ export class TorandCommand implements BaseCommand {
   async execute(
     discord: Discord,
     message: Message<true>,
-    args: string[]
+    arguments_: string[]
   ): Promise<void> {
-    const text = args.join(' ')
+    const text = arguments_.join(' ')
 
     const config = discord.getConfig()
     const translate = new Translate(config)

--- a/src/commands/toswja.ts
+++ b/src/commands/toswja.ts
@@ -10,9 +10,9 @@ export class ToswjaCommand implements BaseCommand {
   async execute(
     discord: Discord,
     message: Message<true>,
-    args: string[]
+    arguments_: string[]
   ): Promise<void> {
-    const text = args.join(' ')
+    const text = arguments_.join(' ')
 
     const config = discord.getConfig()
     const translate = new Translate(config)

--- a/src/commands/tozh.ts
+++ b/src/commands/tozh.ts
@@ -10,9 +10,9 @@ export class TozhCommand implements BaseCommand {
   async execute(
     discord: Discord,
     message: Message<true>,
-    args: string[]
+    arguments_: string[]
   ): Promise<void> {
-    const text = args.join(' ')
+    const text = arguments_.join(' ')
 
     const config = discord.getConfig()
     const translate = new Translate(config)

--- a/src/commands/tozhja.ts
+++ b/src/commands/tozhja.ts
@@ -10,9 +10,9 @@ export class TozhjaCommand implements BaseCommand {
   async execute(
     discord: Discord,
     message: Message<true>,
-    args: string[]
+    arguments_: string[]
   ): Promise<void> {
-    const text = args.join(' ')
+    const text = arguments_.join(' ')
 
     const config = discord.getConfig()
     const translate = new Translate(config)

--- a/src/commands/translate.ts
+++ b/src/commands/translate.ts
@@ -10,10 +10,10 @@ export class TranslateCommand implements BaseCommand {
   async execute(
     discord: Discord,
     message: Message<true>,
-    args: string[]
+    arguments_: string[]
   ): Promise<void> {
     // 引数は最低3つ必要
-    if (args.length < 3) {
+    if (arguments_.length < 3) {
       await message.reply(
         ':x: 引数が足りません。`/translate <before> <after> <text>` の形式で入力してください。'
       )
@@ -21,9 +21,9 @@ export class TranslateCommand implements BaseCommand {
     }
 
     // 翻訳前の言語、翻訳後の言語、翻訳するテキストを取得
-    const beforeLanguage = args[0]
-    const afterLanguage = args[1]
-    const text = args.slice(2).join(' ')
+    const beforeLanguage = arguments_[0]
+    const afterLanguage = arguments_[1]
+    const text = arguments_.slice(2).join(' ')
 
     const config = discord.getConfig()
     const translate = new Translate(config)

--- a/src/config.ts
+++ b/src/config.ts
@@ -31,7 +31,7 @@ export interface ConfigInterface {
   }
 }
 
-export class Configuration extends ConfigFramework<ConfigInterface> {
+export class Config extends ConfigFramework<ConfigInterface> {
   protected validates(): Record<string, (config: ConfigInterface) => boolean> {
     return {
       'discord is required': (config) => !!config.discord,

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -8,7 +8,7 @@ import {
 } from 'discord.js'
 import { Logger } from '@book000/node-utils'
 import { BaseDiscordEvent } from './events'
-import { Configuration } from './config'
+import { Config } from './config'
 import { BaseCommand } from './commands'
 import { PingCommand } from './commands/ping'
 import { TmttmtCommand } from './commands/tmttmt'
@@ -62,7 +62,7 @@ import { SetbannerExtraCommand } from './commands/setbannerextra'
 import { GreetingTimeoutTask } from './tasks/greeting-timeout'
 
 export class Discord {
-  private config: Configuration
+  private config: Config
   public readonly client: Client
 
   private readonly tasks: BaseDiscordTask[] = []
@@ -100,7 +100,7 @@ export class Discord {
     new UnmuteCommand(),
   ]
 
-  constructor(config: Configuration) {
+  constructor(config: Config) {
     this.client = new Client({
       intents: [
         GatewayIntentBits.Guilds,
@@ -124,12 +124,16 @@ export class Discord {
       if (!message.inGuild()) {
         return
       }
-      this.onMessageCreate(message).catch((error: unknown) => {
-        Logger.configure('Discord.onMessageCreate').error(
-          '❌ Error',
-          error as Error
-        )
-      })
+      ;(async () => {
+        try {
+          await this.onMessageCreate(message)
+        } catch (error: unknown) {
+          Logger.configure('Discord.onMessageCreate').error(
+            '❌ Error',
+            error as Error
+          )
+        }
+      })()
     })
 
     const events: BaseDiscordEvent<any>[] = [
@@ -150,9 +154,17 @@ export class Discord {
       event.register()
     }
 
-    this.client.login(config.get('discord').token).catch((error: unknown) => {
-      Logger.configure('Discord.login').error('❌ login failed', error as Error)
-    })
+    const client = this.client
+    ;(async () => {
+      try {
+        await client.login(config.get('discord').token)
+      } catch (error: unknown) {
+        Logger.configure('Discord.login').error(
+          '❌ login failed',
+          error as Error
+        )
+      }
+    })()
 
     this.tasks = [
       new MeetingVoteTask(this),
@@ -161,12 +173,16 @@ export class Discord {
       new GreetingTimeoutTask(this),
     ]
     for (const task of this.tasks) {
-      task.register().catch((error: unknown) => {
-        Logger.configure('Discord.task').error(
-          '❌ task register failed',
-          error as Error
-        )
-      })
+      ;(async () => {
+        try {
+          await task.register()
+        } catch (error: unknown) {
+          Logger.configure('Discord.task').error(
+            '❌ task register failed',
+            error as Error
+          )
+        }
+      })()
     }
 
     const crons: BaseDiscordJob[] = [new EveryDayJob(this)]
@@ -194,14 +210,17 @@ export class Discord {
     logger.info(`👌 ready: ${this.client.user?.tag}`)
 
     for (const task of this.tasks) {
-      task.execute().catch((error: unknown) => {
-        logger.error('❌ task execute failed', error as Error)
-      })
+      ;(async () => {
+        try {
+          await task.execute()
+        } catch (error: unknown) {
+          logger.error('❌ task execute failed', error as Error)
+        }
+      })()
     }
   }
 
   async onMessageCreate(message: Message<true>) {
-    const logger = Logger.configure('Discord.onMessageCreate')
     // Botのメッセージは無視
     if (message.author.bot) {
       return
@@ -222,6 +241,8 @@ export class Discord {
       // コマンドが見つからない場合は無視
       return
     }
+
+    const logger = Logger.configure('Discord.onMessageCreate')
 
     // コマンドの実行権限を確認
     if (command.permissions) {
@@ -258,9 +279,9 @@ export class Discord {
 
     logger.info(`👌 ${message.author.tag}: execute ${command.name}`)
 
-    const [, ...args] = message.content.split(' ')
+    const [, ...arguments_] = message.content.split(' ')
     try {
-      await command.execute(this, message, args)
+      await command.execute(this, message, arguments_)
     } catch (error) {
       // エラー処理
       logger.error('❌ Error', error as Error)

--- a/src/events/greeting.ts
+++ b/src/events/greeting.ts
@@ -1,6 +1,6 @@
 import { Message } from 'discord.js'
 import { BaseDiscordEvent } from '.'
-import { Configuration } from '@/config'
+import { Config } from '@/config'
 
 /**
  * #greeting チャンネルでの挨拶を処理するイベント
@@ -23,11 +23,9 @@ export class GreetingEvent extends BaseDiscordEvent<'messageCreate'> {
   readonly eventName = 'messageCreate'
 
   async execute(message: Message<true>): Promise<void> {
-    const config: Configuration = this.discord.getConfig()
+    const config: Config = this.discord.getConfig()
     const greetingChannelId =
       config.get('discord').channel?.greeting ?? '1149587870273773569'
-    const verifiedRoleId =
-      config.get('discord').role?.verified ?? '1149583365708709940'
 
     // #greeting チャンネル以外は無視
     if (message.channel.id !== greetingChannelId) return
@@ -42,6 +40,8 @@ export class GreetingEvent extends BaseDiscordEvent<'messageCreate'> {
       return
     }
 
+    const verifiedRoleId =
+      config.get('discord').role?.verified ?? '1149583365708709940'
     const member = message.member
     const isMailVerified = member.roles.cache.has(verifiedRoleId)
 
@@ -52,7 +52,7 @@ export class GreetingEvent extends BaseDiscordEvent<'messageCreate'> {
         this.jaoPostedUsers.add(message.author.id)
       }
 
-      const emoji = isMailVerified ? '\u274C' : '\u27A1'
+      const emoji = isMailVerified ? '\u{274C}' : '\u{27A1}'
       await message.react(emoji)
       return
     }
@@ -60,20 +60,20 @@ export class GreetingEvent extends BaseDiscordEvent<'messageCreate'> {
     // afa メッセージの場合
     if (isMailVerified) {
       // MailVerifiedがついている: \u274C をリアクション
-      await message.react('\u274C')
+      await message.react('\u{274C}')
       return
     }
 
     // MailVerifiedがついていない
     if (!this.jaoPostedUsers.has(message.author.id)) {
       // jaoPostedUsersに投稿者が含まれていない: \u274C をリアクション
-      await message.react('\u274C')
+      await message.react('\u{274C}')
       return
     }
 
     // jaoPostedUsersに投稿者が含まれている: \u2B55 をリアクション、jaoPostedUsersから削除
     this.jaoPostedUsers.delete(message.author.id)
-    await message.react('\u2B55')
+    await message.react('\u{2B55}')
 
     const roles = message.member.roles
     const hasMainRole =

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -13,10 +13,14 @@ export abstract class BaseDiscordEvent<T extends keyof ClientEvents> {
 
   register(): void {
     this.discord.client.on(this.eventName, (...eventArguments) => {
-      this.execute(...eventArguments).catch((error: unknown) => {
-        const logger = Logger.configure('BaseDiscordEvent')
-        logger.error('❌ Error', error as Error)
-      })
+      ;(async () => {
+        try {
+          await this.execute(...eventArguments)
+        } catch (error: unknown) {
+          const logger = Logger.configure('BaseDiscordEvent')
+          logger.error('❌ Error', error as Error)
+        }
+      })()
     })
   }
 

--- a/src/events/joined-notifier.ts
+++ b/src/events/joined-notifier.ts
@@ -1,6 +1,6 @@
 import { ChannelType, GuildMember } from 'discord.js'
 import { BaseDiscordEvent } from '.'
-import { Configuration } from '@/config'
+import { Config } from '@/config'
 
 /**
  * ユーザーがサーバに参加した際、以下の処理を行う
@@ -11,7 +11,7 @@ export class JoinedNotifierEvent extends BaseDiscordEvent<'guildMemberAdd'> {
   readonly eventName = 'guildMemberAdd'
 
   async execute(member: GuildMember): Promise<void> {
-    const config: Configuration = this.discord.getConfig()
+    const config: Config = this.discord.getConfig()
     const generalChannelId =
       config.get('discord').channel?.general ?? '1138605147287728150'
     const greetingChannelId =

--- a/src/events/leaved-notifier.ts
+++ b/src/events/leaved-notifier.ts
@@ -1,6 +1,6 @@
 import { ChannelType, GuildMember } from 'discord.js'
 import { BaseDiscordEvent } from '.'
-import { Configuration } from '@/config'
+import { Config } from '@/config'
 
 /**
  * ユーザーがサーバから退出した際、以下の処理を行う
@@ -10,7 +10,7 @@ export class LeavedNotififerEvent extends BaseDiscordEvent<'guildMemberRemove'> 
   readonly eventName = 'guildMemberRemove'
 
   async execute(member: GuildMember): Promise<void> {
-    const config: Configuration = this.discord.getConfig()
+    const config: Config = this.discord.getConfig()
     const generalChannelId =
       config.get('discord').channel?.general ?? '1138605147287728150'
 

--- a/src/events/meeting-vote-new.ts
+++ b/src/events/meeting-vote-new.ts
@@ -1,6 +1,6 @@
 import { ChannelType, Message } from 'discord.js'
 import { BaseDiscordEvent } from '.'
-import { Configuration } from '../config'
+import { Config } from '../config'
 import { MeetingVote } from '../features/meeting-vote'
 
 /**
@@ -10,7 +10,7 @@ export class MeetingNewVoteEvent extends BaseDiscordEvent<'messageCreate'> {
   readonly eventName = 'messageCreate'
 
   async execute(message: Message<true>): Promise<void> {
-    const config: Configuration = this.discord.getConfig()
+    const config: Config = this.discord.getConfig()
     const meetingVoteChannelId =
       config.get('discord').channel?.meetingVote ?? '1149598703846440960'
 
@@ -23,12 +23,11 @@ export class MeetingNewVoteEvent extends BaseDiscordEvent<'messageCreate'> {
     // サーバのテキストチャンネル以外は無視
     if (message.channel.type !== ChannelType.GuildText) return
 
-    const channel = message.channel
-    const meetingVoteFeature = new MeetingVote(channel)
-
     // すでにピン留めされたメッセージは無視
     if (message.pinned) return
 
+    const channel = message.channel
+    const meetingVoteFeature = new MeetingVote(channel)
     await meetingVoteFeature.newVoteMessage(message)
   }
 }

--- a/src/events/meeting-vote-reaction.ts
+++ b/src/events/meeting-vote-reaction.ts
@@ -9,7 +9,7 @@ import {
   Colors,
 } from 'discord.js'
 import { BaseDiscordEvent } from '.'
-import { Configuration } from '../config'
+import { Config } from '../config'
 import { MeetingVote } from '../features/meeting-vote'
 import { setTimeout } from 'node:timers/promises'
 import { Logger } from '@book000/node-utils'
@@ -24,7 +24,7 @@ export class MeetingReactionVoteEvent extends BaseDiscordEvent<'messageReactionA
     reaction: MessageReaction | PartialMessageReaction,
     user: User | PartialUser
   ): Promise<void> {
-    const config: Configuration = this.discord.getConfig()
+    const config: Config = this.discord.getConfig()
     const meetingVoteChannelId =
       config.get('discord').channel?.meetingVote ?? '1149598703846440960'
 
@@ -40,11 +40,11 @@ export class MeetingReactionVoteEvent extends BaseDiscordEvent<'messageReactionA
     // サーバのテキストチャンネル以外は無視
     if (message.channel.type !== ChannelType.GuildText) return
 
-    const channel = message.channel
-    const meetingVoteFeature = new MeetingVote(channel)
-
     // ピン留めされていないメッセージは無視
     if (!message.pinned) return
+
+    const channel = message.channel
+    const meetingVoteFeature = new MeetingVote(channel)
 
     // PartialUserの場合はfetch
     if (user.partial) {
@@ -92,13 +92,14 @@ export class MeetingReactionVoteEvent extends BaseDiscordEvent<'messageReactionA
       },
     })
 
-    setTimeout(60_000)
-      .then(async () => {
+    ;(async () => {
+      try {
+        await setTimeout(60_000)
         await reply.delete()
-      })
-      .catch((error: unknown) => {
+      } catch (error: unknown) {
         logger.error('Failed to delete message', error as Error)
-      })
+      }
+    })()
   }
 
   async executeUserHasNoVoteRight(
@@ -125,12 +126,13 @@ export class MeetingReactionVoteEvent extends BaseDiscordEvent<'messageReactionA
       },
     })
 
-    setTimeout(60_000)
-      .then(async () => {
+    ;(async () => {
+      try {
+        await setTimeout(60_000)
         await reply.delete()
-      })
-      .catch((error: unknown) => {
+      } catch (error: unknown) {
         logger.error('Failed to delete message', error as Error)
-      })
+      }
+    })()
   }
 }

--- a/src/events/new-discussion-mention.ts
+++ b/src/events/new-discussion-mention.ts
@@ -9,7 +9,7 @@ export class NewDiscussionMention extends BaseDiscordEvent<'threadCreate'> {
 
   async execute(
     thread: AnyThreadChannel,
-    newlyCreated: boolean
+    isNewlyCreated: boolean
   ): Promise<void> {
     const config = this.discord.getConfig()
     const discussionChannelId =
@@ -22,7 +22,7 @@ export class NewDiscussionMention extends BaseDiscordEvent<'threadCreate'> {
       return
     }
     // 新規作成でない場合は無視
-    if (!newlyCreated) return
+    if (!isNewlyCreated) return
 
     const adminRoleId =
       config.get('discord').role?.admin ?? '1138605444600963163'

--- a/src/events/nitrotan-message.ts
+++ b/src/events/nitrotan-message.ts
@@ -61,7 +61,7 @@ export class NitrotanMessageEvent extends BaseDiscordEvent<'messageCreate'> {
   private isAnimationEmojiMessage(message: Message<true>): boolean {
     const matches = message.content.matchAll(this.emojiRegex)
 
-    return [...matches].some((match) => match.groups?.animated === 'a')
+    return matches.some((match) => match.groups?.animated === 'a')
   }
 
   /**
@@ -75,7 +75,7 @@ export class NitrotanMessageEvent extends BaseDiscordEvent<'messageCreate'> {
 
     const guildEmojis = message.guild.emojis.cache
 
-    return [...matches].some((match) => {
+    return matches.some((match) => {
       const emojiId = match.groups?.id
       if (!emojiId) return false
       return !guildEmojis.has(emojiId)

--- a/src/events/vc-speech-log-url.ts
+++ b/src/events/vc-speech-log-url.ts
@@ -1,6 +1,6 @@
 import { ChannelType, Colors, EmbedBuilder, Message } from 'discord.js'
 import { BaseDiscordEvent } from '.'
-import { Configuration } from '../config'
+import { Config } from '../config'
 
 /**
  * #vc-speech-log へのメッセージリンクが投稿された際、リンク先メッセージの内容を引用する
@@ -12,10 +12,6 @@ export class VCSpeechLogMessageUrlEvent extends BaseDiscordEvent<'messageCreate'
   readonly eventName = 'messageCreate'
 
   async execute(message: Message<true>): Promise<void> {
-    const config: Configuration = this.discord.getConfig()
-    const vcSpeechLogChannelId =
-      config.get('discord').channel?.vcSpeechLog ?? '1149606247314767993'
-
     // メンバーが取得できない場合は無視
     if (!message.member) return
     // Botは無視
@@ -25,8 +21,10 @@ export class VCSpeechLogMessageUrlEvent extends BaseDiscordEvent<'messageCreate'
     const messageUrlMatch = message.content.match(this.messageUrlRegex)
     if (!messageUrlMatch) return
 
+    const config: Config = this.discord.getConfig()
+    const vcSpeechLogChannelId =
+      config.get('discord').channel?.vcSpeechLog ?? '1149606247314767993'
     const urlChannelId = messageUrlMatch[2]
-    const urlMessageId = messageUrlMatch[3]
 
     // #vc-speech-log チャンネル以外は無視
     if (urlChannelId !== vcSpeechLogChannelId) return
@@ -35,6 +33,7 @@ export class VCSpeechLogMessageUrlEvent extends BaseDiscordEvent<'messageCreate'
     const vcSpeechLogChannel = await message.guild.channels.fetch(urlChannelId)
     if (vcSpeechLogChannel?.type !== ChannelType.GuildText) return
 
+    const urlMessageId = messageUrlMatch[3]
     const vcSpeechLogMessage =
       await vcSpeechLogChannel.messages.fetch(urlMessageId)
 

--- a/src/features/birthday.test.ts
+++ b/src/features/birthday.test.ts
@@ -3,12 +3,12 @@ import { Birthday, IBirthdayDateWithYear } from './birthday'
 import 'jest-expect-message'
 
 describe('Birthday', () => {
-  let beforeDataDir: string | undefined
+  let beforeDataDirectory: string | undefined
   let birthday: Birthday
 
   beforeEach(() => {
     // テストデータはテンポラリディレクトリに保存する
-    beforeDataDir = process.env.DATA_DIR
+    beforeDataDirectory = process.env.DATA_DIR
     process.env.DATA_DIR = tmpdir()
 
     birthday = new Birthday()
@@ -18,7 +18,7 @@ describe('Birthday', () => {
     // テストデータをクリアする
     birthday.delete('testUser')
 
-    process.env.DATA_DIR = beforeDataDir
+    process.env.DATA_DIR = beforeDataDirectory
   })
 
   it('ファイルから誕生日データを追加して読み込む', () => {
@@ -86,12 +86,7 @@ describe('Birthday', () => {
     birthday.set('testUser', { month: 1, day: 1, year: 2000 })
 
     // 異常な値の誕生日を設定
-    const ages = [
-      Number.POSITIVE_INFINITY,
-      Number.NEGATIVE_INFINITY,
-      Number.NaN,
-      -1,
-    ]
+    const ages = [Infinity, -Infinity, Number.NaN, -1]
 
     for (const age of ages) {
       // テストユーザーの強制年齢を異常な値で設定

--- a/src/features/birthday.ts
+++ b/src/features/birthday.ts
@@ -190,9 +190,9 @@ export class Birthday {
    * @returns ファイルパス
    */
   private getPath() {
-    const dataDir = process.env.DATA_DIR ?? 'data/'
+    const dataDirectory = process.env.DATA_DIR ?? 'data/'
 
-    return `${dataDir}/birthday.json`
+    return `${dataDirectory}/birthday.json`
   }
 
   /**
@@ -290,8 +290,6 @@ export class Birthday {
    */
   public static isValidDate(date: IBirthdayDateWithYear): boolean {
     const month = date.month
-    const day = date.day
-    const year = date.year
 
     // 月は1〜12であること
     if (month < 1 || month > 12) {
@@ -299,11 +297,13 @@ export class Birthday {
     }
 
     // 日は1〜31であること
+    const day = date.day
     if (day < 1 || day > 31) {
       return false
     }
 
     // 年はnullまたは0以上であること
+    const year = date.year
     if (year !== null && year < 0) {
       return false
     }
@@ -343,10 +343,10 @@ export class Birthday {
   /**
    * 数値を2桁の0埋めした文字列に変換する
    *
-   * @param num 数値
+   * @param number_ 数値
    * @returns 2桁の0埋めした文字列
    */
-  private static getZeroPadding(num: number): string {
-    return num.toString().padStart(2, '0')
+  private static getZeroPadding(number_: number): string {
+    return number_.toString().padStart(2, '0')
   }
 }

--- a/src/features/google-search.ts
+++ b/src/features/google-search.ts
@@ -75,18 +75,18 @@ export class GoogleSearch {
       url += `&searchType=${searchType}`
     }
 
-    const res = await fetch(url)
+    const response = await fetch(url)
     let data: any
-    const responseText = await res.text()
+    const responseText = await response.text()
     try {
       data = JSON.parse(responseText) as GoogleCustomSearchResponse
     } catch {
       data = responseText
     }
     this.incrementRequestCount()
-    this.saveResponse(res.status, data)
-    if (res.status !== 200) {
-      throw new Error(`Google Custom Search API failed: ${res.status}`)
+    this.saveResponse(response.status, data)
+    if (response.status !== 200) {
+      throw new Error(`Google Custom Search API failed: ${response.status}`)
     }
 
     // searchInformation, itemsがあることを確認
@@ -130,10 +130,9 @@ export class GoogleSearch {
     const matches = html.matchAll(pattern)
     let result = html
     for (const match of matches) {
-      const code = match[1]
-        ? Number.parseInt(match[1], 10)
-        : Number.parseInt(match[2], 16)
-      result = result.replaceAll(match[0], String.fromCodePoint(code))
+      const code = match[1] ? Number(match[1]) : Number.parseInt(match[2], 16)
+      const replacement = String.fromCodePoint(code)
+      result = result.replaceAll(match[0], () => replacement)
     }
 
     const replaceMap = {
@@ -146,7 +145,7 @@ export class GoogleSearch {
       '&nbsp;': ' ',
     }
     for (const [key, value] of Object.entries(replaceMap)) {
-      result = result.replaceAll(key, value)
+      result = result.replaceAll(key, () => value)
     }
 
     // 太字
@@ -174,7 +173,7 @@ export class GoogleSearch {
       json = JSON.parse(data)
     }
 
-    if (!(date in json)) {
+    if (!Object.hasOwn(json, date)) {
       json[date] = 0
     }
     json[date]++
@@ -196,7 +195,7 @@ export class GoogleSearch {
     // リセットタイミングはPST0時
     // タイムゾーンを考慮して日付を取得
     const date = this.getPstDate()
-    if (!(date in json)) {
+    if (!Object.hasOwn(json, date)) {
       return 0
     }
 

--- a/src/features/kinenbi.test.ts
+++ b/src/features/kinenbi.test.ts
@@ -5,38 +5,38 @@ import { Kinenbi } from './kinenbi'
 import 'jest-expect-message'
 
 describe('Kinenbi', () => {
-  let beforeDataDir: string | undefined
-  let testDataDir: string
+  let beforeDataDirectory: string | undefined
+  let testDataDirectory: string
   let kinenbi: Kinenbi
 
   beforeEach(() => {
     // テストデータはテンポラリディレクトリに保存する
-    beforeDataDir = process.env.DATA_DIR
-    testDataDir = path.join(tmpdir(), `kinenbi-test-${Date.now()}`)
-    process.env.DATA_DIR = testDataDir
+    beforeDataDirectory = process.env.DATA_DIR
+    testDataDirectory = path.join(tmpdir(), `kinenbi-test-${Date.now()}`)
+    process.env.DATA_DIR = testDataDirectory
 
     kinenbi = new Kinenbi()
   })
 
   afterEach(() => {
     // テストデータをクリアする
-    if (existsSync(testDataDir)) {
-      rmSync(testDataDir, { recursive: true, force: true })
+    if (existsSync(testDataDirectory)) {
+      rmSync(testDataDirectory, { recursive: true, force: true })
     }
 
-    process.env.DATA_DIR = beforeDataDir
+    process.env.DATA_DIR = beforeDataDirectory
   })
 
   describe('getRanking', () => {
     it('同点を含む順位計算が正しく動作する', async () => {
       // テストキャッシュディレクトリを作成
-      const cacheDir = path.join(testDataDir, 'kinenbi-cache')
-      mkdirSync(cacheDir, { recursive: true })
+      const cacheDirectory = path.join(testDataDirectory, 'kinenbi-cache')
+      mkdirSync(cacheDirectory, { recursive: true })
 
       // テストデータを作成（異なる記念日個数のファイル）
       // 01-01: 5個（1位）
       writeFileSync(
-        path.join(cacheDir, '01-01.json'),
+        path.join(cacheDirectory, '01-01.json'),
         JSON.stringify({
           cachedDate: '2026-01-01T00:00:00.000Z',
           results: [
@@ -51,7 +51,7 @@ describe('Kinenbi', () => {
 
       // 02-09: 3個（2位）- 今日として扱う
       writeFileSync(
-        path.join(cacheDir, '02-09.json'),
+        path.join(cacheDirectory, '02-09.json'),
         JSON.stringify({
           cachedDate: '2026-02-09T00:00:00.000Z',
           results: [
@@ -64,7 +64,7 @@ describe('Kinenbi', () => {
 
       // 03-15: 3個（2位、同点）
       writeFileSync(
-        path.join(cacheDir, '03-15.json'),
+        path.join(cacheDirectory, '03-15.json'),
         JSON.stringify({
           cachedDate: '2026-03-15T00:00:00.000Z',
           results: [
@@ -77,7 +77,7 @@ describe('Kinenbi', () => {
 
       // 12-31: 1個（4位）
       writeFileSync(
-        path.join(cacheDir, '12-31.json'),
+        path.join(cacheDirectory, '12-31.json'),
         JSON.stringify({
           cachedDate: '2025-12-31T00:00:00.000Z',
           results: [{ title: '大晦日' }],
@@ -102,12 +102,12 @@ describe('Kinenbi', () => {
 
     it('今日のキャッシュファイルが存在しない場合に null を返す', async () => {
       // テストキャッシュディレクトリを作成
-      const cacheDir = path.join(testDataDir, 'kinenbi-cache')
-      mkdirSync(cacheDir, { recursive: true })
+      const cacheDirectory = path.join(testDataDirectory, 'kinenbi-cache')
+      mkdirSync(cacheDirectory, { recursive: true })
 
       // 他の日のキャッシュファイルのみ作成
       writeFileSync(
-        path.join(cacheDir, '01-01.json'),
+        path.join(cacheDirectory, '01-01.json'),
         JSON.stringify({
           cachedDate: '2026-01-01T00:00:00.000Z',
           results: [{ title: '元日' }],
@@ -122,12 +122,12 @@ describe('Kinenbi', () => {
 
     it('壊れた JSON ファイルをスキップして処理を続行する', async () => {
       // テストキャッシュディレクトリを作成
-      const cacheDir = path.join(testDataDir, 'kinenbi-cache')
-      mkdirSync(cacheDir, { recursive: true })
+      const cacheDirectory = path.join(testDataDirectory, 'kinenbi-cache')
+      mkdirSync(cacheDirectory, { recursive: true })
 
       // 正常な今日のキャッシュファイル
       writeFileSync(
-        path.join(cacheDir, '02-09.json'),
+        path.join(cacheDirectory, '02-09.json'),
         JSON.stringify({
           cachedDate: '2026-02-09T00:00:00.000Z',
           results: [{ title: '記念日1' }, { title: '記念日2' }],
@@ -135,11 +135,11 @@ describe('Kinenbi', () => {
       )
 
       // 壊れた JSON ファイル
-      writeFileSync(path.join(cacheDir, '01-01.json'), 'invalid json {')
+      writeFileSync(path.join(cacheDirectory, '01-01.json'), 'invalid json {')
 
       // 正常なファイル
       writeFileSync(
-        path.join(cacheDir, '12-31.json'),
+        path.join(cacheDirectory, '12-31.json'),
         JSON.stringify({
           cachedDate: '2025-12-31T00:00:00.000Z',
           results: [{ title: '大晦日' }],
@@ -156,12 +156,12 @@ describe('Kinenbi', () => {
 
     it('results が配列でない場合に null を返す', async () => {
       // テストキャッシュディレクトリを作成
-      const cacheDir = path.join(testDataDir, 'kinenbi-cache')
-      mkdirSync(cacheDir, { recursive: true })
+      const cacheDirectory = path.join(testDataDirectory, 'kinenbi-cache')
+      mkdirSync(cacheDirectory, { recursive: true })
 
       // results が配列でないファイル
       writeFileSync(
-        path.join(cacheDir, '02-09.json'),
+        path.join(cacheDirectory, '02-09.json'),
         JSON.stringify({
           cachedDate: '2026-02-09T00:00:00.000Z',
           results: 'not an array',
@@ -175,12 +175,12 @@ describe('Kinenbi', () => {
 
     it('すべてのファイルが壊れている場合に null を返す', async () => {
       // テストキャッシュディレクトリを作成
-      const cacheDir = path.join(testDataDir, 'kinenbi-cache')
-      mkdirSync(cacheDir, { recursive: true })
+      const cacheDirectory = path.join(testDataDirectory, 'kinenbi-cache')
+      mkdirSync(cacheDirectory, { recursive: true })
 
       // 今日のキャッシュファイル（正常）
       writeFileSync(
-        path.join(cacheDir, '02-09.json'),
+        path.join(cacheDirectory, '02-09.json'),
         JSON.stringify({
           cachedDate: '2026-02-09T00:00:00.000Z',
           results: [{ title: '記念日1' }],
@@ -188,8 +188,8 @@ describe('Kinenbi', () => {
       )
 
       // 他のファイルはすべて壊れている
-      writeFileSync(path.join(cacheDir, '01-01.json'), 'invalid json')
-      writeFileSync(path.join(cacheDir, '12-31.json'), '{invalid}')
+      writeFileSync(path.join(cacheDirectory, '01-01.json'), 'invalid json')
+      writeFileSync(path.join(cacheDirectory, '12-31.json'), '{invalid}')
 
       const ranking = await kinenbi.getRanking(new Date('2026-02-09'))
 
@@ -202,12 +202,12 @@ describe('Kinenbi', () => {
 
     it('記念日が0個の日でも正しく順位を計算する', async () => {
       // テストキャッシュディレクトリを作成
-      const cacheDir = path.join(testDataDir, 'kinenbi-cache')
-      mkdirSync(cacheDir, { recursive: true })
+      const cacheDirectory = path.join(testDataDirectory, 'kinenbi-cache')
+      mkdirSync(cacheDirectory, { recursive: true })
 
       // 今日のキャッシュファイル（0個）
       writeFileSync(
-        path.join(cacheDir, '02-09.json'),
+        path.join(cacheDirectory, '02-09.json'),
         JSON.stringify({
           cachedDate: '2026-02-09T00:00:00.000Z',
           results: [],
@@ -216,7 +216,7 @@ describe('Kinenbi', () => {
 
       // 他の日のキャッシュファイル
       writeFileSync(
-        path.join(cacheDir, '01-01.json'),
+        path.join(cacheDirectory, '01-01.json'),
         JSON.stringify({
           cachedDate: '2026-01-01T00:00:00.000Z',
           results: [{ title: '元日' }],

--- a/src/features/kinenbi.ts
+++ b/src/features/kinenbi.ts
@@ -38,20 +38,20 @@ export class Kinenbi {
    * 指定した日付の記念日一覧を取得します。
    *
    * @param date 日付
-   * @param force キャッシュを無視して強制的に取得するかどうか
+   * @param isForced キャッシュを無視して強制的に取得するかどうか
    * @returns 記念日一覧
    */
   public async get(
     date: Date,
-    force = false
+    isForced = false
   ): Promise<KinenbiResultWithCustom[]> {
     const cachePath = this.getCachePath(date)
-    const prevData: KinenbiCache | null = fs.existsSync(cachePath)
+    const previousData: KinenbiCache | null = fs.existsSync(cachePath)
       ? JSON.parse(fs.readFileSync(cachePath, 'utf8'))
       : null
 
-    if (!force && prevData) {
-      return prevData.results
+    if (!isForced && previousData) {
+      return previousData.results
     }
 
     const body = new URLSearchParams({
@@ -59,16 +59,16 @@ export class Kinenbi {
       M: (date.getMonth() + 1).toString(),
       D: date.getDate().toString(),
     })
-    const res = await fetch(this.baseUrl, {
+    const response = await fetch(this.baseUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
       body: body.toString(),
     })
-    if (res.status !== 200) {
-      throw new Error('Failed to get today: ' + res.status.toString())
+    if (response.status !== 200) {
+      throw new Error('Failed to get today: ' + response.status.toString())
     }
 
-    const html = await res.text()
+    const html = await response.text()
     const $ = load(html)
     const elements = $('div.today_kinenbilist a.winDetail')
 
@@ -86,24 +86,24 @@ export class Kinenbi {
         continue
       }
 
-      const searchParamsObject = this.searchParamsToObject(
+      const searchParametersObject = this.searchParamsToObject(
         kinenbiUrlObject.searchParams
       )
-      const lastFoundDate = prevData?.results.find(
+      const lastFoundDate = previousData?.results.find(
         (result) =>
           result.detail.filename === filename &&
-          result.detail.query.TYPE === searchParamsObject.TYPE &&
-          result.detail.query.MD === searchParamsObject.MD &&
-          result.detail.query.NM === searchParamsObject.NM
+          result.detail.query.TYPE === searchParametersObject.TYPE &&
+          result.detail.query.MD === searchParametersObject.MD &&
+          result.detail.query.NM === searchParametersObject.NM
       )?.foundDate
       const foundDate = lastFoundDate ?? date // キャッシュがある場合は前回の日付を使う
-      const isNew = prevData !== null && lastFoundDate === undefined // キャッシュがある場合は新規かどうかを判定
+      const isNew = previousData !== null && lastFoundDate === undefined // キャッシュがある場合は新規かどうかを判定
 
       results.push({
         title,
         detail: {
           filename,
-          query: searchParamsObject,
+          query: searchParametersObject,
         },
         foundDate,
         isNew,
@@ -125,10 +125,10 @@ export class Kinenbi {
     const urlObject = new URL(this.baseUrl + options.filename)
     urlObject.search = this.objectToSearchParams(options.query).toString()
 
-    const res = await fetch(urlObject.toString())
+    const response = await fetch(urlObject.href)
     // 正しくても404が返ってくることがある
 
-    const html = await res.text()
+    const html = await response.text()
     const $ = load(html)
 
     const title = $('td[nowarp] > font:nth-child(1)').text()
@@ -157,11 +157,11 @@ export class Kinenbi {
     const logger = Logger.configure('Kinenbi.getRanking')
 
     try {
-      const dataDir = process.env.DATA_DIR ?? 'data/'
-      const cacheDir = `${dataDir}/kinenbi-cache/`
+      const dataDirectory = process.env.DATA_DIR ?? 'data/'
+      const cacheDirectory = `${dataDirectory}/kinenbi-cache/`
 
       // キャッシュディレクトリの存在確認
-      if (!fs.existsSync(cacheDir)) {
+      if (!fs.existsSync(cacheDirectory)) {
         return null
       }
 
@@ -182,14 +182,14 @@ export class Kinenbi {
 
       // すべてのキャッシュファイルを読み込んで記念日個数をカウント
       // 今日のファイルも counts に含めて集計する
-      const files = await fsp.readdir(cacheDir)
+      const files = await fsp.readdir(cacheDirectory)
       const jsonFiles = files.filter((file) => file.endsWith('.json'))
 
       const counts: number[] = []
 
       for (const file of jsonFiles) {
         try {
-          const filePath = `${cacheDir}${file}`
+          const filePath = `${cacheDirectory}${file}`
           const fileData: unknown = JSON.parse(
             await fsp.readFile(filePath, 'utf8')
           )
@@ -242,32 +242,31 @@ export class Kinenbi {
   }
 
   private getCachePath(date: Date): string {
-    const dataDir = process.env.DATA_DIR ?? 'data/'
-    const cacheDir = `${dataDir}/kinenbi-cache/`
+    const dataDirectory = process.env.DATA_DIR ?? 'data/'
+    const cacheDirectory = `${dataDirectory}/kinenbi-cache/`
     const cacheFile = `${(date.getMonth() + 1).toString().padStart(2, '0')}-${date.getDate().toString().padStart(2, '0')}.json`
 
-    if (!fs.existsSync(cacheDir)) {
-      fs.mkdirSync(cacheDir, { recursive: true })
+    if (!fs.existsSync(cacheDirectory)) {
+      fs.mkdirSync(cacheDirectory, { recursive: true })
     }
 
-    return `${cacheDir}${cacheFile}`
+    return `${cacheDirectory}${cacheFile}`
   }
 
   private searchParamsToObject(
-    searchParams: URLSearchParams
+    searchParameters: URLSearchParams
   ): Record<string, string> {
-    const result: Record<string, string> = {}
-    for (const [key, value] of searchParams) {
-      result[key] = value
-    }
+    const result: Record<string, string> = Object.fromEntries(searchParameters)
     return result
   }
 
-  private objectToSearchParams(obj: Record<string, string>): URLSearchParams {
-    const searchParams = new URLSearchParams()
-    for (const key in obj) {
-      searchParams.append(key, obj[key])
+  private objectToSearchParams(
+    object: Record<string, string>
+  ): URLSearchParams {
+    const searchParameters = new URLSearchParams()
+    for (const key in object) {
+      searchParameters.append(key, object[key])
     }
-    return searchParams
+    return searchParameters
   }
 }

--- a/src/features/mebo.ts
+++ b/src/features/mebo.ts
@@ -34,7 +34,7 @@ export class Mebo {
     const uid = options.uid
 
     try {
-      const res = await fetch(this.apiUrl, {
+      const response = await fetch(this.apiUrl, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -44,10 +44,10 @@ export class Mebo {
           uid: `jaotan-reply-${uid}`,
         }),
       })
-      if (!res.ok) {
+      if (!response.ok) {
         return null
       }
-      return (await res.json()) as MeboResponse
+      return (await response.json()) as MeboResponse
     } catch {
       return null
     }

--- a/src/features/meeting-vote.ts
+++ b/src/features/meeting-vote.ts
@@ -37,12 +37,12 @@ class VoteReaction {
    * 指定したメッセージでこのリアクションをつけたユーザーを取得します。
    *
    * @param message メッセージ
-   * @param excludeBot Botを除外するかどうか
+   * @param isExcludingBot Botを除外するかどうか
    * @returns ユーザーのコレクション
    */
   public async getUsers(
     message: Message<true>,
-    excludeBot = false
+    isExcludingBot = false
   ): Promise<Collection<string, User>> {
     message = await message.fetch()
 
@@ -51,7 +51,7 @@ class VoteReaction {
       return new Collection<string, User>()
     }
     const users = await reaction.users.fetch()
-    return excludeBot ? users.filter((user: User) => !user.bot) : users
+    return isExcludingBot ? users.filter((user: User) => !user.bot) : users
   }
 
   /**
@@ -77,19 +77,19 @@ export const VoteReactionType = {
   /**
    * 賛成
    */
-  Good: new VoteReaction('\uD83D\uDC4D'),
+  Good: new VoteReaction('\u{1F44D}'),
   /**
    * 反対
    */
-  Bad: new VoteReaction('\uD83D\uDC4E'),
+  Bad: new VoteReaction('\u{1F44E}'),
   /**
    * 白票
    */
-  White: new VoteReaction('\uD83C\uDFF3'),
+  White: new VoteReaction('\u{1F3F3}'),
   /**
    * リマインド済み
    */
-  Remind: new VoteReaction('\uD83D\uDCF3'),
+  Remind: new VoteReaction('\u{1F4F3}'),
 } as const
 
 /**
@@ -310,11 +310,11 @@ export class MeetingVote {
     // 投票開始から1週間が経過していて、リマインド済みでない場合、リマインドする
     // リマインドした場合、Bot自身がリアクションをつける
     const voteRemindDateTime = this.getVoteRemindDateTime(message)
-    const reminded = await VoteReactionType.Remind.isReacted(
+    const isReminded = await VoteReactionType.Remind.isReacted(
       message,
       message.client.user.id
     )
-    if (voteRemindDateTime < new Date() && !reminded) {
+    if (voteRemindDateTime < new Date() && !isReminded) {
       await this.remind(message, goodUsers, badUsers, whiteUsers)
     }
   }

--- a/src/features/nitrotan.ts
+++ b/src/features/nitrotan.ts
@@ -1,6 +1,6 @@
 import { Discord } from '@/discord'
 import { Logger } from '@book000/node-utils'
-import { Guild, Role, TextChannel } from 'discord.js'
+import { Channel, Guild, Role, TextChannel } from 'discord.js'
 import fs from 'node:fs'
 
 export const NitrotanReason = {
@@ -71,9 +71,15 @@ export class Nitrotan {
 
     const channelId =
       config.get('discord').channel?.other ?? '1149857948089192448'
-    const channel =
-      discord.client.channels.cache.get(channelId) ??
-      (await discord.client.channels.fetch(channelId).catch(() => null))
+    let channel: Channel | null | undefined =
+      discord.client.channels.cache.get(channelId)
+    if (!channel) {
+      try {
+        channel = await discord.client.channels.fetch(channelId)
+      } catch {
+        channel = null
+      }
+    }
     if (!channel) {
       throw new Error('Channel not found')
     }
@@ -93,9 +99,14 @@ export class Nitrotan {
     }
 
     const roleId = config.get('discord').role?.nitrotan ?? '1149583556138508328'
-    const role =
-      guild.roles.cache.get(roleId) ??
-      (await guild.roles.fetch(roleId).catch(() => null))
+    let role: Role | null | undefined = guild.roles.cache.get(roleId)
+    if (!role) {
+      try {
+        role = await guild.roles.fetch(roleId)
+      } catch {
+        role = null
+      }
+    }
 
     if (!role) {
       throw new Error('Role not found')
@@ -108,10 +119,10 @@ export class Nitrotan {
    * ファイルからNitroユーザーデータを読み込む。
    * 最終読み込み日時から30分以上経過している場合は読み込む。
    *
-   * @param force 最終読み込み日時を無視して強制的に読み込むか
+   * @param isForced 最終読み込み日時を無視して強制的に読み込むか
    */
-  public load(force = false) {
-    if (!force && Nitrotan.lastLoadAt) {
+  public load(isForced = false) {
+    if (!isForced && Nitrotan.lastLoadAt) {
       const now = new Date()
       const diff = now.getTime() - Nitrotan.lastLoadAt.getTime()
       if (diff < 30 * 60 * 1000) {
@@ -162,11 +173,11 @@ export class Nitrotan {
    * ユーザーをNitroとして認識する
    */
   public async add(discordId: string, reason: NitrotanReasonType) {
-    const logger = Logger.configure('Nitrotan.add')
     if (this.isNitrotan(discordId)) {
       return
     }
 
+    const logger = Logger.configure('Nitrotan.add')
     Nitrotan.nitrotans.push({
       discordId,
       since: new Date(),
@@ -317,7 +328,11 @@ export class Nitrotan {
       return cacheMember
     }
 
-    return await this.guild.members.fetch(discordId).catch(() => null)
+    try {
+      return await this.guild.members.fetch(discordId)
+    } catch {
+      return null
+    }
   }
 
   /**
@@ -330,8 +345,8 @@ export class Nitrotan {
    * @returns ファイルパス
    */
   private getPath() {
-    const dataDir = process.env.DATA_DIR ?? 'data/'
+    const dataDirectory = process.env.DATA_DIR ?? 'data/'
 
-    return `${dataDir}/nitrotan.json`
+    return `${dataDirectory}/nitrotan.json`
   }
 }

--- a/src/features/translate.ts
+++ b/src/features/translate.ts
@@ -1,4 +1,4 @@
-import { Configuration } from '@/config'
+import { Config } from '@/config'
 import DetectLanguage from 'detectlanguage'
 import {
   BaseMessageOptions,
@@ -144,15 +144,14 @@ export class Translate {
     zu: 'ズールー語',
   }
 
-  constructor(config: Configuration) {
+  constructor(config: Config) {
     const translateGasUrl = config.get('translateGasUrl')
-    const detectLanguageApiToken = config.get('detectLanguageApiToken')
     if (!translateGasUrl) {
       throw new Error('translateGasUrl is required')
     }
 
     this.translateGasUrl = translateGasUrl
-    this.detectLanguageApiToken = detectLanguageApiToken ?? null
+    this.detectLanguageApiToken = config.get('detectLanguageApiToken') ?? null
   }
 
   async translate(
@@ -167,7 +166,7 @@ export class Translate {
       throw new Error('Invalid after language')
     }
 
-    const res = await fetch(this.translateGasUrl, {
+    const response = await fetch(this.translateGasUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -176,11 +175,11 @@ export class Translate {
         text,
       }),
     })
-    if (res.status !== 200) {
+    if (response.status !== 200) {
       throw new Error('Failed to translate')
     }
 
-    const data = (await res.json()) as TranslateResponse
+    const data = (await response.json()) as TranslateResponse
     return {
       beforeLanguage,
       afterLanguage,
@@ -259,8 +258,8 @@ export class Translate {
     // 翻訳処理
     // afterLanguagesの順番で翻訳。翻訳後の言語が複数ある場合は、翻訳後の言語の数だけ繰り返す
     const fields: EmbedField[] = []
-    for (let i = 0; i < afterLanguages.length; i++) {
-      const language = afterLanguages[i]
+    for (let index = 0; index < afterLanguages.length; index++) {
+      const language = afterLanguages[index]
 
       if (beforeLanguage === language) {
         await reply.edit(
@@ -286,11 +285,11 @@ export class Translate {
       })
 
       // 翻訳結果を送信
-      const type = i === afterLanguages.length - 1 ? 'SUCCESS' : 'PENDING'
+      const type = index === afterLanguages.length - 1 ? 'SUCCESS' : 'PENDING'
       const title =
-        i === afterLanguages.length - 1
+        index === afterLanguages.length - 1
           ? '翻訳完了'
-          : `翻訳中 (${i + 1}/${afterLanguages.length})`
+          : `翻訳中 (${index + 1}/${afterLanguages.length})`
 
       await reply.edit(this.getEmbedMessage(type, title, null, fields))
 

--- a/src/jobs/everyday.ts
+++ b/src/jobs/everyday.ts
@@ -1,6 +1,6 @@
 import { Birthday } from '@/features/birthday'
 import { BaseDiscordJob } from '.'
-import { Configuration } from '@/config'
+import { Config } from '@/config'
 import { ChannelType } from 'discord.js'
 import { Kinenbi } from '@/features/kinenbi'
 
@@ -11,7 +11,7 @@ export class EveryDayJob extends BaseDiscordJob {
   readonly schedule = '0 0 * * *'
 
   async execute(): Promise<void> {
-    const config: Configuration = this.discord.getConfig()
+    const config: Config = this.discord.getConfig()
     const generalChannelId =
       config.get('discord').channel?.general ?? '1138605147287728150'
 
@@ -104,31 +104,31 @@ export class EveryDayJob extends BaseDiscordJob {
     const todayKinenbi = await kinenbi.get(date, true)
     const contents = []
 
-    let isAlreadyAddedDetail = false
-
     if (todayKinenbi.length === 0) {
       contents.push('本日の記念日が存在しないか、取得できませんでした。')
       return contents
     }
 
-    let num = 0
+    let isAlreadyAddedDetail = false
+
+    let number_ = 0
     for (const result of todayKinenbi) {
-      num++
+      number_++
       const newSuffix = result.isNew ? ':new:' : ''
 
       if (isAlreadyAddedDetail) {
-        contents.push(`${num}. ${result.title} ${newSuffix}`)
+        contents.push(`${number_}. ${result.title} ${newSuffix}`)
         continue
       }
 
       const detail = await kinenbi.getDetail(result.detail)
       if (detail.description.includes('毎月')) {
-        contents.push(`${num}. ${result.title} ${newSuffix}`)
+        contents.push(`${number_}. ${result.title} ${newSuffix}`)
         continue
       }
 
       contents.push(
-        `${num}. ${result.title} ${newSuffix}\`\`\`${detail.description}\`\`\``
+        `${number_}. ${result.title} ${newSuffix}\`\`\`${detail.description}\`\`\``
       )
       isAlreadyAddedDetail = true
     }

--- a/src/jobs/index.ts
+++ b/src/jobs/index.ts
@@ -16,10 +16,12 @@ export abstract class BaseDiscordJob {
     const logger = Logger.configure(`${this.constructor.name}.register`)
     cron.schedule(
       this.schedule,
-      () => {
-        this.execute().catch((error: unknown) => {
+      async () => {
+        try {
+          await this.execute()
+        } catch (error: unknown) {
           logger.error('❌ job failed', error as Error)
-        })
+        }
       },
       {
         timezone: 'Asia/Tokyo',

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,10 @@
 import { Logger } from '@book000/node-utils'
-import { Configuration } from './config'
+import { Config } from './config'
 import { Discord } from './discord'
 
 function main() {
   const logger = Logger.configure('main')
-  const config = new Configuration('data/config.json')
+  const config = new Config('data/config.json')
   config.load()
   if (!config.validate()) {
     logger.error('❌ Configuration is invalid')
@@ -18,17 +18,16 @@ function main() {
   const discord = new Discord(config)
   process.once('SIGINT', () => {
     logger.info('👋 SIGINT signal received.')
-    discord
-      .close()
-      .then(() => {
+    ;(async () => {
+      try {
+        await discord.close()
         logger.info('👋 Discord client closed.')
-      })
-      .catch((error: unknown) => {
+      } catch (error: unknown) {
         logger.error('❌ Discord client close failed.', error as Error)
-      })
-      .finally(() => {
+      } finally {
         process.exit(0)
-      })
+      }
+    })()
   })
 }
 

--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -12,8 +12,9 @@ export abstract class BaseDiscordTask {
   abstract get interval(): number
 
   async register(): Promise<void> {
+    const interval = setInterval(this.interval * 1000)
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    for await (const _ of setInterval(this.interval * 1000)) {
+    for await (const _ of interval) {
       await this.execute()
     }
   }

--- a/src/tasks/meeting-vote.ts
+++ b/src/tasks/meeting-vote.ts
@@ -1,6 +1,6 @@
 import { ChannelType } from 'discord.js'
 import { BaseDiscordTask } from '.'
-import { Configuration } from '../config'
+import { Config } from '../config'
 import { MeetingVote } from '../features/meeting-vote'
 
 /**
@@ -13,7 +13,7 @@ export class MeetingVoteTask extends BaseDiscordTask {
   }
 
   async execute(): Promise<void> {
-    const config: Configuration = this.discord.getConfig()
+    const config: Config = this.discord.getConfig()
     const meetingVoteChannelId =
       config.get('discord').channel?.meetingVote ?? '1149598703846440960'
 


### PR DESCRIPTION
## Summary

Renovate PR #2063 bumps `@book000/eslint-config` from `1.15.4` to `1.15.44`, which pulls in a newer `eslint-plugin-unicorn`. The new ruleset flags 133 pre-existing style issues across `src/` (abbreviated identifiers, promise chaining instead of `try`/`await`/`catch`, declarations placed before early-exit guards, etc.), which is why the Renovate PR's CI (`Node CI / node-ci`) fails.

This PR applies the mechanical, behavior-preserving fixes so the codebase lints clean under the newer config, without bumping `@book000/eslint-config` itself (that belongs to #2063, not this PR).

## Changes

- Renamed abbreviated identifiers per `unicorn/prevent-abbreviations`-adjacent naming rules (`args` → `arguments_`, `res` → `response`, `ctx` → `context`, `dataDir`/`cacheDir` → `dataDirectory`/`cacheDirectory`, `Configuration` → `Config`, etc.)
- Converted `.then()/.catch()` promise chains to `try`/`await`/`catch`, wrapped in self-invoking async IIFEs where needed for sync callback contexts (event listeners, constructors, `SIGINT` handler), per this repo's `no-void` + `ignoreIIFE: true` convention
- Reordered `const`/`let` declarations to come after early-return guards (`unicorn/no-declarations-before-early-exit`)
- Fixed misc. rule violations: boolean naming (`unicorn/consistent-boolean-name`), `url.href` over `.toString()`, `Object.hasOwn` over `in`, iterator helpers over spread-then-array-method, global `Infinity` over `Number.POSITIVE_INFINITY`/`NEGATIVE_INFINITY`

## Verification

- `pnpm run lint` (eslint, prettier, tsc) passes clean under both the current `1.15.4` and the target `1.15.44` `@book000/eslint-config`, **except** one line in `birthday.test.ts`: `unicorn/prefer-number-properties` (1.15.4) and `unicorn/prefer-global-number-constants` (1.15.44) disagree on `Number.NaN` vs. plain `NaN`. Kept the `1.15.4`-compatible form (`Number.NaN`) since that's what this branch's own CI runs against; #2063's own bump will need to flip that one literal when it lands.
- `pnpm run test` — all 26 existing tests pass, no behavioral changes intended.
