### PR TITLE
fix: Renovate 設定を共有プリセット book000/templates//renovate/base に統一

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,8 +1,5 @@
 {
-  "extends": ["config:base", ":disableRateLimiting"],
-  "timezone": "Asia/Tokyo",
-  "dependencyDashboard": false,
-  "automerge": true,
-  "platformAutomerge": true,
-  "assignees": ["book000"]
+  "extends": [
+    "github>book000/templates//renovate/base"
+  ]
 }


### PR DESCRIPTION
## 概要

`.github/renovate.json` を、jaoafa の他リポジトリと同じ共有プリセット `github>book000/templates//renovate/base` を extends する形に統一する。

## 背景 / 課題

これまで本リポジトリの Renovate 設定は `config:base` のみを extends しており、共有プリセットが持つ `minimumReleaseAge`(旧 `stabilityDays: 3`)のガードが効いていなかった。

一方で pnpm v11 は `minimumReleaseAge` のデフォルトが 1440 分(24 時間)であり、`pnpm install` 時に公開後 24 時間未満のパッケージを含む lockfile を拒否する。ガードのない Renovate は公開直後のパッケージ更新を即座に PR 化するため、pnpm 側の 24 時間制限に引っかかって CI が失敗するタイミングレースが発生していた(#2147 で `prettier` 更新が失敗した原因)。

## 変更内容

- `.github/renovate.json` を共有プリセット `github>book000/templates//renovate/base` の extends 1 本に置き換え。
- 従来個別に指定していた `timezone` / `dependencyDashboard` / `automerge` / `platformAutomerge` / `assignees` はいずれも共有プリセット側で同値が設定済みのため冗長であり、削除。
- これにより共有プリセットの `stabilityDays: 3`(実効 3 日、`@book000/*` は除外)が適用され、Renovate 側の待機(3 日)が pnpm 側の 24 時間を上回るため、この種の CI 失敗を防ぐ。

## 確認

- `renovate-config-validator` による検証: `Config validated successfully against 1 file(s)`。
- jaoafa の既存リポジトリ(discord-event-notifier, discord-new-threads, watch-guilds)と同一のプリセット構成。
