### PR TITLE
fix(lint): reorder condition in meeting-vote reminder check

### DIFF
--- a/src/features/meeting-vote.ts
+++ b/src/features/meeting-vote.ts
@@ -314,7 +314,7 @@ export class MeetingVote {
       message,
       message.client.user.id
     )
-    if (voteRemindDateTime < new Date() && !reminded) {
+    if (!reminded && voteRemindDateTime < new Date()) {
       await this.remind(message, goodUsers, badUsers, whiteUsers)
     }
   }


### PR DESCRIPTION
## What

Reorders a boolean condition in `src/features/meeting-vote.ts` so the simple check comes first:

```diff
- if (voteRemindDateTime < new Date() && !reminded) {
+ if (!reminded && voteRemindDateTime < new Date()) {
```

## Why

Renovate PR #2138 bumps `@book000/eslint-config` from 1.16.8 to 1.16.14, which newly enables/tightens the `unicorn/prefer-simple-condition-first` rule. This existing condition violates it once that bump lands, which is why #2138's `Node CI` check currently fails.

No behavior change: both operands are pure local reads with no side effects, so swapping the order preserves short-circuit semantics.

Verified locally with `pnpm run lint` (clean).