### PR TITLE
feat: 毎月1日に前月の絵文字利用ランキングを投稿する

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "cheerio": "1.2.0",
     "detectlanguage": "3.0.0",
     "discord.js": "14.27.0",
+    "emoji-regex": "^10.6.0",
     "eslint": "10.7.0",
     "eslint-config-standard": "17.1.0",
     "eslint-plugin-import": "2.32.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       discord.js:
         specifier: 14.27.0
         version: 14.27.0
+      emoji-regex:
+        specifier: ^10.6.0
+        version: 10.6.0
       eslint:
         specifier: 10.7.0
         version: 10.7.0(supports-color@8.1.1)

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -55,6 +55,10 @@ import { ToenCommand } from './commands/toen'
 import { UnmuteCommand } from './commands/unmute'
 import { NitrotanReactionEvent } from './events/nitrotan-reaction'
 import { NitrotanMessageEvent } from './events/nitrotan-message'
+import {
+  EmojiReactionAddEvent,
+  EmojiReactionRemoveEvent,
+} from './events/emoji-reaction'
 import { NitrotanOptimizeTask } from './tasks/nitrotan-optimize'
 import { NitrotanProfileTask } from './tasks/nitrotan-profile'
 import { ReplyEvent } from './events/reply'
@@ -133,6 +137,8 @@ export class Discord {
     })
 
     const events: BaseDiscordEvent<any>[] = [
+      new EmojiReactionAddEvent(this),
+      new EmojiReactionRemoveEvent(this),
       new GreetingEvent(this),
       new JoinedNotifierEvent(this),
       new LeavedNotififerEvent(this),

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -45,6 +45,7 @@ import { NewDiscussionMention } from './events/new-discussion-mention'
 import { BaseDiscordJob } from './jobs'
 import nodeCron from 'node-cron'
 import { EveryDayJob } from './jobs/everyday'
+import { MonthlyEmojiRankingJob } from './jobs/emoji-ranking'
 import { BirthdayCommand } from './commands/birthday'
 import { GetAtamaCommand } from './commands/getatama'
 import { SetbannerCommand } from './commands/setbanner'
@@ -177,7 +178,10 @@ export class Discord {
       })
     }
 
-    const crons: BaseDiscordJob[] = [new EveryDayJob(this)]
+    const crons: BaseDiscordJob[] = [
+      new EveryDayJob(this),
+      new MonthlyEmojiRankingJob(this),
+    ]
     for (const job of crons) {
       job.register(nodeCron)
     }

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -59,6 +59,7 @@ import {
   EmojiReactionAddEvent,
   EmojiReactionRemoveEvent,
 } from './events/emoji-reaction'
+import { EmojiMessageEvent } from './events/emoji-message'
 import { NitrotanOptimizeTask } from './tasks/nitrotan-optimize'
 import { NitrotanProfileTask } from './tasks/nitrotan-profile'
 import { ReplyEvent } from './events/reply'
@@ -137,6 +138,7 @@ export class Discord {
     })
 
     const events: BaseDiscordEvent<any>[] = [
+      new EmojiMessageEvent(this),
       new EmojiReactionAddEvent(this),
       new EmojiReactionRemoveEvent(this),
       new GreetingEvent(this),

--- a/src/events/emoji-message.ts
+++ b/src/events/emoji-message.ts
@@ -1,0 +1,20 @@
+import { Message } from 'discord.js'
+import { BaseDiscordEvent } from '.'
+import { EmojiRanking, extractMessageEmojis } from '@/features/emoji-ranking'
+
+/**
+ * メッセージ投稿に使われた絵文字を集計するイベントハンドラー
+ */
+export class EmojiMessageEvent extends BaseDiscordEvent<'messageCreate'> {
+  readonly eventName = 'messageCreate'
+
+  async execute(message: Message): Promise<void> {
+    if (message.author.bot) return
+    if (!message.inGuild()) return
+
+    const emojis = extractMessageEmojis(message.content)
+    if (emojis.length === 0) return
+
+    new EmojiRanking().addMessageEmojis(emojis)
+  }
+}

--- a/src/events/emoji-message.ts
+++ b/src/events/emoji-message.ts
@@ -8,13 +8,15 @@ import { EmojiRanking, extractMessageEmojis } from '@/features/emoji-ranking'
 export class EmojiMessageEvent extends BaseDiscordEvent<'messageCreate'> {
   readonly eventName = 'messageCreate'
 
-  async execute(message: Message): Promise<void> {
-    if (message.author.bot) return
-    if (!message.inGuild()) return
+  execute(message: Message): Promise<void> {
+    if (message.author.bot) return Promise.resolve()
+    if (!message.inGuild()) return Promise.resolve()
 
     const emojis = extractMessageEmojis(message.content)
-    if (emojis.length === 0) return
+    if (emojis.length > 0) {
+      new EmojiRanking().addMessageEmojis(emojis)
+    }
 
-    new EmojiRanking().addMessageEmojis(emojis)
+    return Promise.resolve()
   }
 }

--- a/src/events/emoji-reaction.ts
+++ b/src/events/emoji-reaction.ts
@@ -1,0 +1,77 @@
+import {
+  MessageReaction,
+  PartialMessageReaction,
+  PartialUser,
+  User,
+} from 'discord.js'
+import { BaseDiscordEvent } from '.'
+import { EmojiInput, EmojiRanking } from '@/features/emoji-ranking'
+
+/**
+ * リアクションに使われた絵文字を、集計用の情報に変換する
+ *
+ * @param reaction リアクション
+ * @returns 集計用の絵文字情報
+ */
+function toEmojiInput(reaction: MessageReaction): EmojiInput {
+  const name = reaction.emoji.name ?? 'unknown'
+
+  if (reaction.emoji.id) {
+    const prefix = reaction.emoji.animated ? 'a' : ''
+    return {
+      kind: 'custom',
+      key: `${name}:${reaction.emoji.id}`,
+      display: `<${prefix}:${name}:${reaction.emoji.id}>`,
+    }
+  }
+
+  return { kind: 'unicode', key: name, display: name }
+}
+
+/**
+ * リアクション追加によって使われた絵文字を集計するイベントハンドラー
+ */
+export class EmojiReactionAddEvent extends BaseDiscordEvent<'messageReactionAdd'> {
+  readonly eventName = 'messageReactionAdd'
+
+  async execute(
+    reaction: MessageReaction | PartialMessageReaction,
+    user: User | PartialUser
+  ): Promise<void> {
+    reaction = reaction.partial ? await reaction.fetch() : reaction
+    user = user.partial ? await user.fetch() : user
+
+    if (user.bot) return
+
+    const message = reaction.message.partial
+      ? await reaction.message.fetch()
+      : reaction.message
+    if (!message.inGuild()) return
+
+    new EmojiRanking().addReaction(toEmojiInput(reaction))
+  }
+}
+
+/**
+ * リアクション取消によって使われなくなった絵文字を集計するイベントハンドラー
+ */
+export class EmojiReactionRemoveEvent extends BaseDiscordEvent<'messageReactionRemove'> {
+  readonly eventName = 'messageReactionRemove'
+
+  async execute(
+    reaction: MessageReaction | PartialMessageReaction,
+    user: User | PartialUser
+  ): Promise<void> {
+    reaction = reaction.partial ? await reaction.fetch() : reaction
+    user = user.partial ? await user.fetch() : user
+
+    if (user.bot) return
+
+    const message = reaction.message.partial
+      ? await reaction.message.fetch()
+      : reaction.message
+    if (!message.inGuild()) return
+
+    new EmojiRanking().removeReaction(toEmojiInput(reaction))
+  }
+}

--- a/src/features/emoji-ranking.test.ts
+++ b/src/features/emoji-ranking.test.ts
@@ -4,6 +4,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import {
   EmojiRanking,
+  extractMessageEmojis,
   getMonthKey,
   getPreviousMonthKey,
 } from './emoji-ranking'
@@ -159,5 +160,55 @@ describe('EmojiRanking', () => {
     expect(reloaded.getRanking('1999-01', 'reactions', 10)).toEqual([
       { kind: 'unicode', key: '😄', display: '😄', count: 1 },
     ])
+  })
+})
+
+describe('extractMessageEmojis', () => {
+  it('Unicode絵文字を抽出する', () => {
+    const result = extractMessageEmojis('おはよう😄よろしく')
+    expect(result).toEqual([{ kind: 'unicode', key: '😄', display: '😄' }])
+  })
+
+  it('カスタム絵文字を抽出する', () => {
+    const result = extractMessageEmojis('こんにちは<:wave:123456789012345678>')
+    expect(result).toEqual([
+      {
+        kind: 'custom',
+        key: 'wave:123456789012345678',
+        display: '<:wave:123456789012345678>',
+      },
+    ])
+  })
+
+  it('アニメーションカスタム絵文字を抽出する', () => {
+    const result = extractMessageEmojis('<a:dance:987654321098765432>')
+    expect(result).toEqual([
+      {
+        kind: 'custom',
+        key: 'dance:987654321098765432',
+        display: '<a:dance:987654321098765432>',
+      },
+    ])
+  })
+
+  it('カスタム絵文字とUnicode絵文字が混在していても両方抽出する', () => {
+    const result = extractMessageEmojis('やった🎉<:wave:123>おめでとう')
+    expect(result).toEqual(
+      expect.arrayContaining([
+        { kind: 'unicode', key: '🎉', display: '🎉' },
+        { kind: 'custom', key: 'wave:123', display: '<:wave:123>' },
+      ])
+    )
+    expect(result).toHaveLength(2)
+  })
+
+  it('同じ絵文字が複数回出現しても1件に重複排除される', () => {
+    const result = extractMessageEmojis('😄😄😄')
+    expect(result).toEqual([{ kind: 'unicode', key: '😄', display: '😄' }])
+  })
+
+  it('絵文字が含まれない場合は空配列を返す', () => {
+    const result = extractMessageEmojis('こんにちは、世界')
+    expect(result).toEqual([])
   })
 })

--- a/src/features/emoji-ranking.test.ts
+++ b/src/features/emoji-ranking.test.ts
@@ -1,4 +1,12 @@
-import { getMonthKey, getPreviousMonthKey } from './emoji-ranking'
+import { tmpdir } from 'node:os'
+import { randomUUID } from 'node:crypto'
+import fs from 'node:fs'
+import path from 'node:path'
+import {
+  EmojiRanking,
+  getMonthKey,
+  getPreviousMonthKey,
+} from './emoji-ranking'
 
 describe('getMonthKey', () => {
   it('Asia/Tokyo基準の年月キーを返す', () => {
@@ -20,5 +28,136 @@ describe('getPreviousMonthKey', () => {
 
   it('1月の場合は前年の12月を返す', () => {
     expect(getPreviousMonthKey('2026-01')).toBe('2025-12')
+  })
+})
+
+describe('EmojiRanking', () => {
+  let beforeDataDir: string | undefined
+  let dataDir: string
+
+  beforeEach(() => {
+    beforeDataDir = process.env.DATA_DIR
+    dataDir = path.join(tmpdir(), `emoji-ranking-test-${randomUUID()}`)
+    fs.mkdirSync(dataDir, { recursive: true })
+    process.env.DATA_DIR = dataDir
+  })
+
+  afterEach(() => {
+    fs.rmSync(dataDir, { recursive: true, force: true })
+    process.env.DATA_DIR = beforeDataDir
+  })
+
+  it('リアクションを加算すると当月のバケットに反映される', () => {
+    const emojiRanking = new EmojiRanking()
+    const month = getMonthKey(new Date())
+
+    emojiRanking.addReaction({ kind: 'unicode', key: '😄', display: '😄' })
+    emojiRanking.addReaction({ kind: 'unicode', key: '😄', display: '😄' })
+
+    const ranking = emojiRanking.getRanking(month, 'reactions', 10)
+    expect(ranking).toEqual([
+      { kind: 'unicode', key: '😄', display: '😄', count: 2 },
+    ])
+  })
+
+  it('リアクションを取り消すとカウントが減算される', () => {
+    const emojiRanking = new EmojiRanking()
+    const month = getMonthKey(new Date())
+
+    emojiRanking.addReaction({ kind: 'unicode', key: '😄', display: '😄' })
+    emojiRanking.addReaction({ kind: 'unicode', key: '😄', display: '😄' })
+    emojiRanking.removeReaction({ kind: 'unicode', key: '😄', display: '😄' })
+
+    const ranking = emojiRanking.getRanking(month, 'reactions', 10)
+    expect(ranking).toEqual([
+      { kind: 'unicode', key: '😄', display: '😄', count: 1 },
+    ])
+  })
+
+  it('カウントが0未満にはならない', () => {
+    const emojiRanking = new EmojiRanking()
+    const month = getMonthKey(new Date())
+
+    emojiRanking.removeReaction({ kind: 'unicode', key: '😄', display: '😄' })
+
+    const ranking = emojiRanking.getRanking(month, 'reactions', 10)
+    expect(ranking).toEqual([])
+  })
+
+  it('メッセージ投稿分の絵文字を加算できる', () => {
+    const emojiRanking = new EmojiRanking()
+    const month = getMonthKey(new Date())
+
+    emojiRanking.addMessageEmojis([
+      { kind: 'unicode', key: '🎉', display: '🎉' },
+      {
+        kind: 'custom',
+        key: 'wave:123',
+        display: '<:wave:123>',
+      },
+    ])
+
+    const ranking = emojiRanking.getRanking(month, 'messages', 10)
+    expect(ranking).toEqual(
+      expect.arrayContaining([
+        { kind: 'unicode', key: '🎉', display: '🎉', count: 1 },
+        { kind: 'custom', key: 'wave:123', display: '<:wave:123>', count: 1 },
+      ])
+    )
+  })
+
+  it('件数降順で上位N件のみ返す', () => {
+    const emojiRanking = new EmojiRanking()
+    const month = getMonthKey(new Date())
+
+    emojiRanking.addReaction({ kind: 'unicode', key: 'a', display: 'a' })
+    emojiRanking.addReaction({ kind: 'unicode', key: 'b', display: 'b' })
+    emojiRanking.addReaction({ kind: 'unicode', key: 'b', display: 'b' })
+    emojiRanking.addReaction({ kind: 'unicode', key: 'c', display: 'c' })
+    emojiRanking.addReaction({ kind: 'unicode', key: 'c', display: 'c' })
+    emojiRanking.addReaction({ kind: 'unicode', key: 'c', display: 'c' })
+
+    const ranking = emojiRanking.getRanking(month, 'reactions', 2)
+    expect(ranking.map((record) => record.key)).toEqual(['c', 'b'])
+  })
+
+  it('件数が同数の場合は元データの並び順を維持する(安定ソート)', () => {
+    const emojiRanking = new EmojiRanking()
+    const month = getMonthKey(new Date())
+
+    emojiRanking.addReaction({ kind: 'unicode', key: 'x', display: 'x' })
+    emojiRanking.addReaction({ kind: 'unicode', key: 'y', display: 'y' })
+    emojiRanking.addReaction({ kind: 'unicode', key: 'z', display: 'z' })
+
+    const ranking = emojiRanking.getRanking(month, 'reactions', 10)
+    expect(ranking.map((record) => record.key)).toEqual(['x', 'y', 'z'])
+  })
+
+  it('存在しない年月を指定すると空配列を返す', () => {
+    const emojiRanking = new EmojiRanking()
+    const ranking = emojiRanking.getRanking('2000-01', 'reactions', 10)
+    expect(ranking).toEqual([])
+  })
+
+  it('月をまたいだ加算は別バケットとして独立している', () => {
+    const emojiRanking = new EmojiRanking()
+
+    emojiRanking.addReaction({ kind: 'unicode', key: '😄', display: '😄' })
+
+    // ファイルを直接書き換えて、当月分のデータを別の月へ移し替える
+    const filePath = path.join(dataDir, 'emoji-ranking.json')
+    const raw = fs.readFileSync(filePath, 'utf8')
+    const data = JSON.parse(raw) as {
+      months: Record<string, unknown>
+    }
+    const [month, monthly] = Object.entries(data.months)[0]
+    data.months = { '1999-01': monthly }
+    fs.writeFileSync(filePath, JSON.stringify(data), 'utf8')
+
+    const reloaded = new EmojiRanking()
+    expect(reloaded.getRanking(month, 'reactions', 10)).toEqual([])
+    expect(reloaded.getRanking('1999-01', 'reactions', 10)).toEqual([
+      { kind: 'unicode', key: '😄', display: '😄', count: 1 },
+    ])
   })
 })

--- a/src/features/emoji-ranking.test.ts
+++ b/src/features/emoji-ranking.test.ts
@@ -1,0 +1,24 @@
+import { getMonthKey, getPreviousMonthKey } from './emoji-ranking'
+
+describe('getMonthKey', () => {
+  it('Asia/Tokyo基準の年月キーを返す', () => {
+    // UTC 2026-01-31T15:30:00Z は Asia/Tokyo で 2026-02-01T00:30:00+09:00
+    const date = new Date('2026-01-31T15:30:00Z')
+    expect(getMonthKey(date)).toBe('2026-02')
+  })
+
+  it('月が1桁の場合も0埋めで返す', () => {
+    const date = new Date('2026-03-15T00:00:00+09:00')
+    expect(getMonthKey(date)).toBe('2026-03')
+  })
+})
+
+describe('getPreviousMonthKey', () => {
+  it('通常の月であれば1つ前の月を返す', () => {
+    expect(getPreviousMonthKey('2026-07')).toBe('2026-06')
+  })
+
+  it('1月の場合は前年の12月を返す', () => {
+    expect(getPreviousMonthKey('2026-01')).toBe('2025-12')
+  })
+})

--- a/src/features/emoji-ranking.ts
+++ b/src/features/emoji-ranking.ts
@@ -1,0 +1,38 @@
+/**
+ * 日付から Asia/Tokyo 基準の年月キー (YYYY-MM) を取得する
+ *
+ * @param date 対象の日時
+ * @returns 年月キー (例: "2026-06")
+ */
+export function getMonthKey(date: Date): string {
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'Asia/Tokyo',
+    year: 'numeric',
+    month: '2-digit',
+  })
+  const parts = formatter.formatToParts(date)
+  const year = parts.find((part) => part.type === 'year')?.value
+  const month = parts.find((part) => part.type === 'month')?.value
+  if (!year || !month) {
+    throw new Error(
+      `Failed to resolve month key from date: ${date.toISOString()}`
+    )
+  }
+  return `${year}-${month}`
+}
+
+/**
+ * 年月キーから、その前月の年月キーを取得する
+ *
+ * @param monthKey 基準となる年月キー (例: "2026-01")
+ * @returns 前月の年月キー (例: "2025-12")
+ */
+export function getPreviousMonthKey(monthKey: string): string {
+  const [yearString, monthString] = monthKey.split('-')
+  const year = Number(yearString)
+  const month = Number(monthString)
+  if (month === 1) {
+    return `${year - 1}-12`
+  }
+  return `${year}-${String(month - 1).padStart(2, '0')}`
+}

--- a/src/features/emoji-ranking.ts
+++ b/src/features/emoji-ranking.ts
@@ -1,3 +1,5 @@
+import fs from 'node:fs'
+
 /**
  * 日付から Asia/Tokyo 基準の年月キー (YYYY-MM) を取得する
  *
@@ -35,4 +37,189 @@ export function getPreviousMonthKey(monthKey: string): string {
     return `${year - 1}-12`
   }
   return `${year}-${String(month - 1).padStart(2, '0')}`
+}
+
+/** 絵文字の種類 */
+export type EmojiKind = 'custom' | 'unicode'
+
+/** 絵文字を一意に識別するための入力情報 */
+export interface EmojiInput {
+  /** 絵文字の種類 */
+  kind: EmojiKind
+  /** 集計キー。カスタム絵文字は "name:id"、Unicode 絵文字は文字そのもの */
+  key: string
+  /** 表示用文字列。カスタム絵文字は "<:name:id>" または "<a:name:id>"、Unicode 絵文字は文字そのもの */
+  display: string
+}
+
+/** 絵文字ごとの集計結果 */
+export interface EmojiUsageRecord extends EmojiInput {
+  /** 集計件数 */
+  count: number
+}
+
+/** 1 か月分の集計データ */
+export interface EmojiMonthlyUsage {
+  /** リアクションの集計 */
+  reactions: EmojiUsageRecord[]
+  /** メッセージ投稿の集計 */
+  messages: EmojiUsageRecord[]
+}
+
+/** 絵文字利用状況の永続化データ */
+export interface EmojiUsageData {
+  /** 年月 (YYYY-MM形式、Asia/Tokyo基準) をキーとした月別集計データ */
+  months: Record<string, EmojiMonthlyUsage>
+}
+
+/** 集計カテゴリ */
+export type EmojiUsageCategory = 'reactions' | 'messages'
+
+/**
+ * 絵文字の利用状況(リアクション・メッセージ投稿)を月別に集計・永続化するクラス
+ */
+export class EmojiRanking {
+  private data: EmojiUsageData = { months: {} }
+
+  /**
+   * コンストラクタ
+   *
+   * ファイルから集計データを読み込む
+   */
+  constructor() {
+    this.load()
+  }
+
+  /**
+   * ファイルから集計データを読み込む
+   *
+   * - ファイルパスは {@link getPath} で取得する
+   * - ファイルが存在しない場合は `Nitrotan.load()` と同様に空データを初期値として作成・保存する
+   */
+  public load(): void {
+    const filePath = this.getPath()
+
+    if (!fs.existsSync(filePath)) {
+      this.data = { months: {} }
+      this.save()
+      return
+    }
+
+    const raw = fs.readFileSync(filePath, 'utf8')
+    this.data = JSON.parse(raw) as EmojiUsageData
+  }
+
+  /**
+   * ファイルに集計データを保存する
+   *
+   * - ファイルパスは {@link getPath} で取得する
+   */
+  public save(): void {
+    const filePath = this.getPath()
+    fs.writeFileSync(filePath, JSON.stringify(this.data, null, 2), 'utf8')
+  }
+
+  /**
+   * リアクションぶんのカウントを、現在の年月のバケットに加算する
+   *
+   * @param emoji 加算対象の絵文字
+   */
+  public addReaction(emoji: EmojiInput): void {
+    this.load()
+    const monthly = this.getOrCreateMonth(getMonthKey(new Date()))
+    this.applyDelta(monthly.reactions, emoji, 1)
+    this.save()
+  }
+
+  /**
+   * リアクション取消ぶんのカウントを、現在の年月のバケットから減算する
+   *
+   * カウントは 0 未満にはならないようクランプする
+   *
+   * @param emoji 減算対象の絵文字
+   */
+  public removeReaction(emoji: EmojiInput): void {
+    this.load()
+    const monthly = this.getOrCreateMonth(getMonthKey(new Date()))
+    this.applyDelta(monthly.reactions, emoji, -1)
+    this.save()
+  }
+
+  /**
+   * メッセージ投稿ぶんのカウントを、現在の年月のバケットに加算する
+   *
+   * 呼び出し側で重複排除済みの配列を渡すこと(1 メッセージにつき同じ絵文字は 1 件として扱う)
+   *
+   * @param emojis 加算対象の絵文字一覧
+   */
+  public addMessageEmojis(emojis: EmojiInput[]): void {
+    this.load()
+    const monthly = this.getOrCreateMonth(getMonthKey(new Date()))
+    for (const emoji of emojis) {
+      this.applyDelta(monthly.messages, emoji, 1)
+    }
+    this.save()
+  }
+
+  /**
+   * 指定した年月・カテゴリの上位ランキングを取得する
+   *
+   * @param month 年月キー (YYYY-MM)
+   * @param category 集計カテゴリ ('reactions' | 'messages')
+   * @param topN 取得する件数
+   * @returns 件数降順の上位 N 件。対象月のデータが存在しない場合は空配列
+   */
+  public getRanking(
+    month: string,
+    category: EmojiUsageCategory,
+    topN: number
+  ): EmojiUsageRecord[] {
+    this.load()
+    const monthly = this.data.months[month]
+    if (!monthly) {
+      return []
+    }
+    return monthly[category]
+      .toSorted((a, b) => b.count - a.count)
+      .slice(0, topN)
+  }
+
+  private getOrCreateMonth(month: string): EmojiMonthlyUsage {
+    const existing = this.data.months[month]
+    if (existing) {
+      return existing
+    }
+    const created: EmojiMonthlyUsage = { reactions: [], messages: [] }
+    this.data.months[month] = created
+    return created
+  }
+
+  private applyDelta(
+    records: EmojiUsageRecord[],
+    emoji: EmojiInput,
+    delta: number
+  ): void {
+    const existing = records.find((record) => record.key === emoji.key)
+    if (existing) {
+      existing.count = Math.max(0, existing.count + delta)
+      return
+    }
+    if (delta > 0) {
+      records.push({ ...emoji, count: delta })
+    }
+  }
+
+  /**
+   * 集計データのファイルパスを取得する
+   *
+   * - 環境変数 DATA_DIR が設定されている場合はそのディレクトリを使用する
+   * - 環境変数 DATA_DIR が設定されていない場合は data/ ディレクトリを使用する
+   * - ファイル名は emoji-ranking.json とする
+   *
+   * @returns ファイルパス
+   */
+  private getPath(): string {
+    const dataDir = process.env.DATA_DIR ?? 'data/'
+    return `${dataDir}/emoji-ranking.json`
+  }
 }

--- a/src/features/emoji-ranking.ts
+++ b/src/features/emoji-ranking.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs'
+import emojiRegex from 'emoji-regex'
 
 /**
  * 日付から Asia/Tokyo 基準の年月キー (YYYY-MM) を取得する
@@ -74,6 +75,37 @@ export interface EmojiUsageData {
 
 /** 集計カテゴリ */
 export type EmojiUsageCategory = 'reactions' | 'messages'
+
+const CUSTOM_EMOJI_PATTERN = /<a?:(\w+):(\d+)>/g
+
+/**
+ * メッセージ本文からカスタム絵文字・Unicode 絵文字を抽出する
+ *
+ * 同じメッセージ内で同じ絵文字が複数回出現しても、キー単位で重複排除し 1 件にまとめる。
+ *
+ * @param content メッセージ本文
+ * @returns 重複排除済みの絵文字一覧
+ */
+export function extractMessageEmojis(content: string): EmojiInput[] {
+  const emojis = new Map<string, EmojiInput>()
+
+  for (const match of content.matchAll(CUSTOM_EMOJI_PATTERN)) {
+    const [full, name, id] = match
+    const key = `${name}:${id}`
+    emojis.set(key, { kind: 'custom', key, display: full })
+  }
+
+  const unicodeMatches = content.match(emojiRegex()) ?? []
+  for (const character of unicodeMatches) {
+    emojis.set(character, {
+      kind: 'unicode',
+      key: character,
+      display: character,
+    })
+  }
+
+  return [...emojis.values()]
+}
 
 /**
  * 絵文字の利用状況(リアクション・メッセージ投稿)を月別に集計・永続化するクラス

--- a/src/features/emoji-ranking.ts
+++ b/src/features/emoji-ranking.ts
@@ -31,7 +31,7 @@ export function getMonthKey(date: Date): string {
  * @returns 前月の年月キー (例: "2025-12")
  */
 export function getPreviousMonthKey(monthKey: string): string {
-  const [yearString, monthString] = monthKey.split('-')
+  const [yearString, monthString] = monthKey.split('-', 2)
   const year = Number(yearString)
   const month = Number(monthString)
   if (month === 1) {
@@ -70,7 +70,7 @@ export interface EmojiMonthlyUsage {
 /** 絵文字利用状況の永続化データ */
 export interface EmojiUsageData {
   /** 年月 (YYYY-MM形式、Asia/Tokyo基準) をキーとした月別集計データ */
-  months: Record<string, EmojiMonthlyUsage>
+  months: Partial<Record<string, EmojiMonthlyUsage>>
 }
 
 /** 集計カテゴリ */
@@ -104,7 +104,7 @@ export function extractMessageEmojis(content: string): EmojiInput[] {
     })
   }
 
-  return [...emojis.values()]
+  return emojis.values().toArray()
 }
 
 /**

--- a/src/jobs/emoji-ranking.ts
+++ b/src/jobs/emoji-ranking.ts
@@ -1,0 +1,67 @@
+import { BaseDiscordJob } from '.'
+import { Configuration } from '@/config'
+import { ChannelType } from 'discord.js'
+import {
+  EmojiRanking,
+  EmojiUsageRecord,
+  getMonthKey,
+  getPreviousMonthKey,
+} from '@/features/emoji-ranking'
+
+/**
+ * 毎月1日0:00に、前月使われた絵文字のランキングを#generalへ投稿する
+ */
+export class MonthlyEmojiRankingJob extends BaseDiscordJob {
+  readonly schedule = '0 0 1 * *'
+
+  async execute(): Promise<void> {
+    const config: Configuration = this.discord.getConfig()
+    const generalChannelId =
+      config.get('discord').channel?.general ?? '1138605147287728150'
+
+    const channel = await this.discord.client.channels.fetch(generalChannelId)
+    if (channel?.type !== ChannelType.GuildText) return
+
+    const previousMonth = getPreviousMonthKey(getMonthKey(new Date()))
+
+    const emojiRanking = new EmojiRanking()
+    const reactionRanking = emojiRanking.getRanking(
+      previousMonth,
+      'reactions',
+      10
+    )
+    const messageRanking = emojiRanking.getRanking(
+      previousMonth,
+      'messages',
+      10
+    )
+
+    const content = [
+      `:bar_chart: __**先月(${previousMonth})の絵文字ランキング**__ :bar_chart:`,
+      '',
+      '**リアクションでよく使われた絵文字**',
+      ...this.formatRanking(reactionRanking),
+      '',
+      '**投稿でよく使われた絵文字**',
+      ...this.formatRanking(messageRanking),
+    ]
+
+    await channel.send(content.join('\n').trim())
+  }
+
+  /**
+   * ランキングデータをメッセージ表示用の文字列配列に整形する
+   *
+   * @param records ランキングデータ(件数降順)
+   * @returns 表示用の文字列配列。データが1件もない場合は代替文言を1行返す
+   */
+  private formatRanking(records: EmojiUsageRecord[]): string[] {
+    if (records.length === 0) {
+      return ['先月は利用がありませんでした']
+    }
+
+    return records.map(
+      (record, index) => `${index + 1}. ${record.display} (${record.count}回)`
+    )
+  }
+}

--- a/src/jobs/emoji-ranking.ts
+++ b/src/jobs/emoji-ranking.ts
@@ -9,10 +9,10 @@ import {
 } from '@/features/emoji-ranking'
 
 /**
- * 毎月1日0:00に、前月使われた絵文字のランキングを#generalへ投稿する
+ * 毎月1日0:30に、前月使われた絵文字のランキングを#generalへ投稿する
  */
 export class MonthlyEmojiRankingJob extends BaseDiscordJob {
-  readonly schedule = '0 0 1 * *'
+  readonly schedule = '30 0 1 * *'
 
   async execute(): Promise<void> {
     const config: Configuration = this.discord.getConfig()


### PR DESCRIPTION
## 概要

毎月1日 0:30 (Asia/Tokyo) に、前月使われた絵文字のランキングを #general へ投稿する機能を追加する。リアクション・メッセージ投稿それぞれについて、カスタム絵文字と Unicode 絵文字をあわせて集計する。

## 実装内容

- `src/features/emoji-ranking.ts`: 絵文字利用状況を月別に集計・永続化する `EmojiRanking` クラス、年月キーのヘルパー関数、メッセージ本文からの絵文字抽出関数
- `src/events/emoji-reaction.ts`: リアクション追加・取消イベントから絵文字利用を集計 (`EmojiReactionAddEvent` / `EmojiReactionRemoveEvent`)
- `src/events/emoji-message.ts`: メッセージ投稿イベントから絵文字利用を集計 (`EmojiMessageEvent`)
- `src/jobs/emoji-ranking.ts`: 毎月1日 0:30 にランキングを投稿する `MonthlyEmojiRankingJob`
- 新規依存: `emoji-regex` (Unicode 絵文字抽出用)

## 動作確認

- `pnpm lint` (prettier + eslint + tsc): エラーなし
- `pnpm test`: 44/44 件成功

Closes #2162

Spec: [Issue comment URL](https://github.com/jaoafa/jaotan.ts/issues/2162#issuecomment-5074996705)
Plan: [Issue comment URL](https://github.com/jaoafa/jaotan.ts/issues/2162#issuecomment-5075113777)